### PR TITLE
Allow to change QoS reliablity model for reliable for best performance tune

### DIFF
--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -76,6 +76,8 @@ public:
 
         auto useSimTime = this->get_parameter( "use_sim_time" ).as_bool();
         RCLCPP_INFO(get_logger(), "LpSlamNode is using sim time: %s", useSimTime ? "yes": "no");
+        const std::string qos_reliability = this->declare_parameter<std::string>(
+            "qos_reliability", "best_effort");
 
         const std::string left_image_topic = this->declare_parameter<std::string>(
             "left_image_topic", "left_image_raw");
@@ -102,7 +104,12 @@ public:
         // the topic settings
         rclcpp::QoS laser_qos(5);
         laser_qos.keep_last(5);
-        laser_qos.best_effort();
+        if (qos_reliability == "best_effort") {
+            laser_qos.best_effort();
+        } else {
+            // reliable
+            laser_qos.reliable();
+        }
         laser_qos.durability_volatile();
 
         auto default_qos = rclcpp::QoS(rclcpp::SystemDefaultsQoS());
@@ -117,7 +124,12 @@ public:
         // the topic settings
         rclcpp::QoS video_qos(10);
         video_qos.keep_last(10);
-        video_qos.best_effort();
+        if (qos_reliability == "best_effort") {
+            video_qos.best_effort();
+        } else {
+            // reliable
+            video_qos.reliable();
+        }
         video_qos.durability_volatile();
 
         m_leftImageSubscription = this->create_subscription<sensor_msgs::msg::Image>(


### PR DESCRIPTION
This fixes poor timings of images and laser scan topic processing while subscribed in ROS2. Average timing between 5Hz image receiving in synthetic testcase (attached [image_ws.zip](https://github.com/lp-research/lpslam_node/files/7389260/image_ws.zip)) decreases from `0.32` for Best Effort to `0.21` seconds for Reliable QoS model. The second is much closer to the actual camera emitting frequency (see full timings measured report in [qos_check.zip](https://github.com/lp-research/lpslam_node/files/7389290/qos_check.zip))