### PR TITLE
Set valid state in transformToLpSlamGlobalState

### DIFF
--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -710,6 +710,8 @@ public:
             -invRot.y(),
             invRot.x(), 0.1};
 
+        ros_state.state.valid = true;
+
         return ros_state;
     }
 


### PR DESCRIPTION
Set `valid` field of returning state to `true` in `transformToLpSlamGlobalState()` conversion routine. This unset state causes to fail `if (lp_laser_to_camera.valid) {` check in `OpenVSLAMStereoTracker::processImage()`, as it uses `lpslam_RequestNavTransformationCallback()` returning this unset `valid`.