### PR TITLE
Read camera parameters for V-SLAM from camera_info topic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(lpslam_interfaces REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 SET(LPSLAM_BUILD_ROS2 ON CACHE BOOL "build with ROS2 support")
 SET(LPSLAM_BUILD_OPENVSLAM ON CACHE BOOL "enable")


### PR DESCRIPTION
This is the patch allowing to read information about the camera from incoming`CameraInfo` topic messages and automatically form input YAML-file for OpenVSLAM. Also, this fixes `configFromFile` field in "lpslam" JSON-file, so no actions from user no more needed. Everything related were moved to input ROS2-parameters of `lpslam_node`.