### PR TITLE
Allow to use OpenVSLAM directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,29 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
-find_package(lpslam_interfaces REQUIRED)
-find_package(yaml-cpp REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
+if (USE_OPENVSLAM_DIRECTLY)
+  find_package(message_filters REQUIRED)
+  find_package(builtin_interfaces REQUIRED)
+  find_package(cv_bridge REQUIRED)
+  if (NOT LPSLAM_BUILD_OPENVSLAM)
+    # This means that openvslam is built separately
+    find_package(openvslam REQUIRED)
+  endif()
+else()
+  find_package(lpslam_interfaces REQUIRED)
+endif()
 
 SET(LPSLAM_BUILD_ROS2 ON CACHE BOOL "build with ROS2 support")
+SET(LPSLAM_BUILD_LPSLAM ON CACHE BOOL "Build LPSLAM module")
 SET(LPSLAM_BUILD_OPENVSLAM ON CACHE BOOL "enable")
 SET(LPSLAM_BUILD_OPENVSLAM_PANGOLIN ON CACHE BOOL "enable")
-add_subdirectory(lpslam)
+SET(USE_PANGOLIN_VIEWER OFF CACHE BOOL "Use Pangolin Viewer")
+SET(USE_OPENVSLAM_DIRECTLY OFF CACHE BOOL "Build with direct usage of OpenVSLAM (w/o lpslam module)")
+
+if (LPSLAM_BUILD_LPSLAM)
+  add_subdirectory(lpslam)
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -43,17 +59,46 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-## Build 
+## Build
+SET(LPSPAM_NODE_SRC src/LpBaseNode.cpp)
+if(USE_OPENVSLAM_DIRECTLY)
+  LIST(APPEND LPSPAM_NODE_SRC src/OpenVSLAMNode.cpp)
+else()
+  LIST(APPEND LPSPAM_NODE_SRC src/LpSlamNode.cpp)
+endif()
+LIST(APPEND LPSPAM_NODE_SRC src/main.cpp)
+
 add_executable(lpslam_node
-  src/LpSlamNode.cpp
+  ${LPSPAM_NODE_SRC}
 )
+
+SET(LPSPAM_NODE_LIBS
+  ${OPENZEN_TARGET_NAME}
+)
+
+if(USE_OPENVSLAM_DIRECTLY)
+  LIST(APPEND LPSPAM_NODE_LIBS openvslam)
+  target_include_directories(lpslam_node
+    PRIVATE
+    lpslam/src/Interface)
+
+  if(USE_PANGOLIN_VIEWER)
+    LIST(APPEND LPSPAM_NODE_LIBS pangolin_viewer)
+    if (NOT LPSLAM_BUILD_LPSLAM)
+      # If build lpslam with conan, it will add pangolin dependency.
+      # Otherwise, adding it manually
+      LIST(APPEND LPSPAM_NODE_LIBS pangolin)
+    endif()
+  endif()
+else()
+  LIST(APPEND LPSPAM_NODE_LIBS lpslam)
+endif()
 
 target_link_libraries(lpslam_node
-  ${OPENZEN_TARGET_NAME}
-  lpslam
+  ${LPSPAM_NODE_LIBS}
 )
 
-ament_target_dependencies(lpslam_node
+SET(LPSPAM_NODE_DEPS
   rclcpp
   std_msgs
   sensor_msgs
@@ -61,11 +106,28 @@ ament_target_dependencies(lpslam_node
   tf2
   tf2_ros
   tf2_geometry_msgs
-  lpslam_interfaces)
+  yaml_cpp_vendor
+)
+
+if(USE_OPENVSLAM_DIRECTLY)
+  LIST(APPEND LPSPAM_NODE_DEPS message_filters builtin_interfaces cv_bridge)
+  target_compile_definitions(lpslam_node PRIVATE -DUSE_OPENVSLAM_DIRECTLY)
+else()
+  LIST(APPEND LPSPAM_NODE_DEPS lpslam_interfaces)
+endif()
+
+if(USE_PANGOLIN_VIEWER)
+  target_compile_definitions(lpslam_node PRIVATE -DUSE_PANGOLIN_VIEWER)
+endif()
+
+ament_target_dependencies(lpslam_node
+  ${LPSPAM_NODE_DEPS})
 
 install(TARGETS lpslam_node
   DESTINATION lib/${PROJECT_NAME})
-install(TARGETS lpslam
-  DESTINATION lib/${PROJECT_NAME})
+if (LPSLAM_BUILD_LPSLAM)
+  install(TARGETS lpslam
+    DESTINATION lib/${PROJECT_NAME})
+endif()
 
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,10 @@
   <depend>tf2</depend>
   <depend>nav_msgs</depend>
   <depend>lpslam_interfaces</depend>
+  <depend>yaml_cpp_vendor</depend>
+  <depend>message_filters</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>cv_bridge</depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>

--- a/src/LpBaseNode.cpp
+++ b/src/LpBaseNode.cpp
@@ -125,7 +125,7 @@ void LpBaseNode::lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &
     if (!state.valid)  {
         RCLCPP_DEBUG(get_logger(), "SLAM Tracking state invalid, wont use it.");
 
-           // send out the last transform we know
+        // send out the last transform we know
         if (m_lastTransform.has_value())  {
             auto msg = m_lastTransform.value();
             msg.header.stamp = this->now() + m_transform_tolerance;

--- a/src/LpBaseNode.cpp
+++ b/src/LpBaseNode.cpp
@@ -1,0 +1,497 @@
+// Copyright (C) 2021 LP-Research Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "LpBaseNode.hpp"
+
+/*
+nice explainer:
+https://www.stereolabs.com/docs/ros2/video/
+*/
+
+LpBaseNode::LpBaseNode() : Node("lpslam_node")
+{
+    if (!setParameters()) {
+        return;
+    }
+
+    initTransforms();
+}
+
+bool LpBaseNode::setParameters()
+{
+    auto useSimTime = this->get_parameter( "use_sim_time" ).as_bool();
+    RCLCPP_INFO(get_logger(), "VSLAM node is using sim time: %s", useSimTime ? "yes": "no");
+
+    // general VSLAM parameters
+    m_vSlamMethod = "OpenVSLAM";
+    m_slamStarted = false;
+
+    // source switches
+    m_useOdometry = this->declare_parameter<bool>("use_odometry", true);
+    m_consumeLaser = this->declare_parameter<bool>("consume_laser", true);
+    m_isStereoCamera = this->declare_parameter<bool>("stereo_camera", true);
+    m_isCombinedStereoImage = this->declare_parameter<bool>("combined_stereo_image", false);
+
+    // frame ids
+    m_map_frame_id = this->declare_parameter<std::string>("map_frame_id", "map");
+    m_camera_frame_id = this->declare_parameter<std::string>("camera_frame_id", "camera_link");
+    m_odom_frame_id = this->declare_parameter<std::string>("odom_frame_id", "odom");
+    m_base_frame_id = this->declare_parameter<std::string>("base_frame_id", "base_link");
+    m_laserscan_frame_id = this->declare_parameter<std::string>("laserscan_frame_id", "laser");
+
+    // topics and rates
+    m_qosReliability = this->declare_parameter<std::string>(
+        "qos_reliability", "best_effort");
+    m_laserscanTopic = this->declare_parameter<std::string>("laserscan_topic", "scan");
+    m_leftImageTopic = this->declare_parameter<std::string>(
+        "left_image_topic", "left_image_raw");
+    m_rightImageTopic = this->declare_parameter<std::string>(
+        "right_image_topic", "right_image_raw");
+    m_cameraInfoTopic = this->declare_parameter<std::string>(
+        "camera_info_topic", "");
+    m_cameraFps = this->declare_parameter<double>("camera_fps", 5.0);
+    m_pointcloudTopic = this->declare_parameter<std::string>("pointcloud_topic", "slam_features");
+    m_pointcloudRate = this->declare_parameter<int>("pointcloud_rate", 10);
+    m_mapName = this->declare_parameter<std::string>("map_name", "/map");
+    m_mapRate = this->declare_parameter<int>("map_rate", 5);
+
+    const auto transformToleranceFloat = this->declare_parameter<float>("transform_tolerance", 0.5);
+    m_transform_tolerance = tf2::durationFromSec(transformToleranceFloat);
+
+    // OpenVSLAM parameters
+    m_openVSlam_maxNumKeypoints = this->declare_parameter<int>(
+        m_vSlamMethod + "." + "max_num_keypoints", 1000);
+    m_openVSlam_iniMaxNumKeypoints = this->declare_parameter<int>(
+        m_vSlamMethod + "." + "ini_max_num_keypoints", 2000);
+    m_openVSlam_scaleFactor = this->declare_parameter<double>(
+        m_vSlamMethod + "." + "scale_factor", 1.2);
+    m_openVSlam_numLevels = this->declare_parameter<int>(
+        m_vSlamMethod + "." + "num_levels", 8);
+    m_openVSlam_iniFastThreshold = this->declare_parameter<int>(
+        m_vSlamMethod + "." + "ini_fast_threshold", 20);
+    m_openVSlam_minFastThreshold = this->declare_parameter<int>(
+        m_vSlamMethod + "." + "min_fast_threshold", 7);
+    m_openVSlam_depthThreshold = this->declare_parameter<double>(
+        m_vSlamMethod + "." + "depth_threshold", 40.0);
+    m_openVSlam_depthmapFactor = this->declare_parameter<double>(
+        m_vSlamMethod + "." + "depthmap_factor", 1.0);
+    m_openVSlam_mappingBaselineDistThr = this->declare_parameter<double>(
+        m_vSlamMethod + "." + "mapping_baseline_dist_thr", 0.1);
+    m_openVSlam_pangolinViewerFps  = this->declare_parameter<double>(
+        m_vSlamMethod + "." + "pangolin_viewer_fps", 10.0);
+
+    m_openVSlamYaml = this->declare_parameter<std::string>(
+        m_vSlamMethod + "." + "config_yaml", "");
+    m_cameraConfigured = false;
+
+    m_openVSlam_cameraEncoding = "";
+
+    return true;
+}
+
+void LpBaseNode::initTransforms()
+{
+    // Initialize transform listener and broadcaster
+    m_tfBuffer = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+        this->get_node_base_interface(),
+        this->get_node_timers_interface());
+    m_tfBuffer->setCreateTimerInterface(timer_interface);
+    m_tfListener = std::make_shared<tf2_ros::TransformListener>(*m_tfBuffer);
+    m_tfBroadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+}
+
+// needs to be public because its called from the outside
+void LpBaseNode::lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &state_in_time)
+{
+    //transformation lpslam -> ROS is
+    // z_ros = x_lpslam
+    // x_ros = z_lpslam
+    // y_ros = -y_lpslam
+
+    auto const &state = state_in_time.state;
+
+    if (!state.valid)  {
+        RCLCPP_DEBUG(get_logger(), "SLAM Tracking state invalid, wont use it.");
+
+           // send out the last transform we know
+        if (m_lastTransform.has_value())  {
+            auto msg = m_lastTransform.value();
+            msg.header.stamp = this->now() + m_transform_tolerance;
+            m_tfBroadcaster->sendTransform(msg);
+            RCLCPP_INFO(get_logger(), "Send out old transform because new one does not exist.");
+        }
+        return;
+    }
+
+    // relevant lines:
+    // https://github.com/SteveMacenski/slam_toolbox/blob/foxy-devel/src/slam_toolbox_common.cpp#L386
+    computeAndPublishTransform(state_in_time);
+}
+
+LpSlamRequestNavTransformation LpBaseNode::lpslam_RequestNavTransformationCallback(LpSlamROSTimestamp ros_time,
+    LpSlamNavDataFrame from_frame,
+    LpSlamNavDataFrame to_frame) {
+
+    LpSlamRequestNavTransformation invalid_res;
+    invalid_res.valid = false;
+
+    RCLCPP_DEBUG(get_logger(), "Requested nav transform for seconds %d nseconds %ld", ros_time.seconds, ros_time.nanoseconds);
+
+    auto lmdMapName = [this](LpSlamNavDataFrame frame_enum )  {
+        if (frame_enum == LpSlamNavDataFrame_Camera) {
+            return m_camera_frame_id;
+        } else if (frame_enum == LpSlamNavDataFrame_Laser) {
+            return m_laserscan_frame_id;
+        } else if (frame_enum == LpSlamNavDataFrame_Odometry) {
+            return m_odom_frame_id;
+        } else {
+            return std::string("");
+        }
+    };
+
+    const auto transformTimeout = rclcpp::Duration::from_nanoseconds(0.1 * std::pow(10.0, 9.0));
+
+    std::optional<geometry_msgs::msg::TransformStamped> transform;
+    auto from_frame_id = lmdMapName(from_frame);
+    auto to_frame_id = lmdMapName(to_frame);
+
+    if (to_frame_id.empty() || from_frame_id.empty()) {
+        RCLCPP_ERROR(get_logger(), "LpSlam fram cannot be converted to ROS frame");
+        return invalid_res;
+    }
+
+    const auto cpp_ros_time = lpSlamToRosTime(ros_time);
+
+    try {
+        transform = m_tfBuffer->lookupTransform(to_frame_id, from_frame_id, cpp_ros_time,
+            transformTimeout);
+    } catch (tf2::TransformException &ex) {
+        RCLCPP_ERROR(get_logger(), "Cannot get transformation for LpSlam Callback %s", ex.what());
+        return invalid_res;
+    }
+
+    const auto lpstate = transformToLpSlamGlobalState(transform.value());
+    return lpstate.state;
+}
+
+LpSlamRequestNavDataResult LpBaseNode::lpslam_RequestNavDataCallback(LpSlamROSTimestamp for_ros_time,
+    LpSlamGlobalStateInTime * odometry,
+    LpSlamGlobalStateInTime * map ) {
+
+    RCLCPP_DEBUG(get_logger(), "Requested nav data for time %i %lu", for_ros_time.seconds, for_ros_time.nanoseconds);
+
+    auto navTime = lpSlamToRosTime(for_ros_time);
+
+    // wait up to 100 ms for transform to arrive, parameter is nanoseconds
+    auto transformTimeout = rclcpp::Duration::from_nanoseconds(0.1 * std::pow(10.0, 9.0));
+
+    std::optional<geometry_msgs::msg::TransformStamped> odomTransform;
+    try {
+        // first: target frame
+        // second: source frame
+        // lookup the full transformation all the way to the camera
+        // this will include the odometry transformation whichis the relevant part here !
+        // because the map -> odom transformation is quite stable over time this
+        // allows us to provide global position input, even if the tracking is lost
+        odomTransform = m_tfBuffer->lookupTransform(m_odom_frame_id, m_camera_frame_id, navTime,
+            transformTimeout);
+    } catch (tf2::TransformException &ex) {
+        RCLCPP_ERROR(get_logger(), "Cannot get odometry transformation: %s", ex.what());
+    }
+
+    std::optional<geometry_msgs::msg::TransformStamped> mapTransform;
+    try {
+        // first: target frame
+        // second: source frame
+        // lookup the full transformation all the way to the camera
+        // this will include the odometry transformation whichis the relevant part here !
+        // because the map -> odom transformation is quite stable over time this
+        // allows us to provide global position input, even if the tracking is lost
+        mapTransform = m_tfBuffer->lookupTransform(m_map_frame_id, m_camera_frame_id, navTime,
+            transformTimeout);
+    } catch (tf2::TransformException &ex) {
+        RCLCPP_ERROR(get_logger(), "Cannot get map transformation: %s", ex.what());
+    }
+
+    // todo handle  case when there is no map transform
+    if (odomTransform.has_value()) {
+        RCLCPP_DEBUG(get_logger(), "odometry transformation to user: %f %f %f  Rot %f %f %f %f",
+            odomTransform->transform.translation.x,
+            odomTransform->transform.translation.y,
+            odomTransform->transform.translation.z,
+            odomTransform->transform.rotation.w,
+            odomTransform->transform.rotation.x,
+            odomTransform->transform.rotation.y,
+            odomTransform->transform.rotation.z);
+
+        *odometry = transformToLpSlamGlobalState(odomTransform.value());
+
+    }
+
+    // todo handle  case when there is no map transform
+    if (mapTransform.has_value()) {
+        RCLCPP_DEBUG(get_logger(), "map transformation to user: %f %f %f  Rot %f %f %f %f",
+            mapTransform->transform.translation.x,
+            mapTransform->transform.translation.y,
+            mapTransform->transform.translation.z,
+            mapTransform->transform.rotation.w,
+            mapTransform->transform.rotation.x,
+            mapTransform->transform.rotation.y,
+            mapTransform->transform.rotation.z);
+
+        *map = transformToLpSlamGlobalState(mapTransform.value());
+
+    }
+
+    if (mapTransform.has_value() && odomTransform.has_value()) {
+        return LpSlamRequestNavDataResult_OdomAndMap;
+    }
+
+    if (mapTransform.has_value() && !odomTransform.has_value()) {
+        return LpSlamRequestNavDataResult_MapOnly;
+    }
+
+    if (!mapTransform.has_value() && odomTransform.has_value()) {
+        return LpSlamRequestNavDataResult_OdomOnly;
+    }
+
+    // invalid odom
+    return LpSlamRequestNavDataResult_None;
+}
+
+void LpBaseNode::computeAndPublishTransform(LpSlamGlobalStateInTime const & state_in_time) {
+    auto const & state = state_in_time.state;
+
+    if (state_in_time.has_ros_timestamp == 0) {
+        RCLCPP_ERROR(get_logger(), "LPSLAM result does not contain ROS timestamp, can't use tracking result");
+        return;
+    }
+
+    auto const imageTimestamp = lpSlamToRosTime(state_in_time.ros_timestamp);
+
+    tf2::Stamped<tf2::Transform> odom_to_map;
+    tf2::Quaternion q(state.orientation.z, -state.orientation.y, state.orientation.x,
+                        state.orientation.w);
+    tf2::Vector3 p(state.position.z,-state.position.y, state.position.x);
+    tf2::Vector3 p_rot = tf2::quatRotate(q, p);
+    tf2::Stamped<tf2::Transform> cam_to_map(
+        tf2::Transform(q, -p_rot), tf2_ros::fromMsg(imageTimestamp), m_camera_frame_id);
+
+    try {
+        geometry_msgs::msg::TransformStamped cam_to_map_msg, base_to_map_msg, odom_to_map_msg;
+
+        // https://github.com/ros2/geometry2/issues/176
+        // not working for some reason...
+        // base_to_map_msg = tf2::toMsg(base_to_map);
+        cam_to_map_msg.header.stamp = imageTimestamp;
+        cam_to_map_msg.header.frame_id = cam_to_map.frame_id_;
+        cam_to_map_msg.transform.translation.x = cam_to_map.getOrigin().getX();
+        cam_to_map_msg.transform.translation.y = cam_to_map.getOrigin().getY();
+        cam_to_map_msg.transform.translation.z = cam_to_map.getOrigin().getZ();
+        cam_to_map_msg.transform.rotation = tf2::toMsg(cam_to_map.getRotation());
+
+        m_tfBuffer->transform(cam_to_map_msg, base_to_map_msg, m_base_frame_id);
+
+        odom_to_map_msg = m_tfBuffer->transform(base_to_map_msg, m_odom_frame_id);
+        tf2::fromMsg(odom_to_map_msg, odom_to_map);
+    } catch (tf2::TransformException & e) {
+        RCLCPP_ERROR(get_logger(), "Transform from base_link to odom failed: %s",
+        e.what());
+        return;
+    }
+
+    // set map to odom for our transformation thread to publish
+    tf2::Transform map_to_odom = tf2::Transform(tf2::Quaternion(odom_to_map.getRotation() ),
+        tf2::Vector3(odom_to_map.getOrigin() ) ).inverse();
+
+    geometry_msgs::msg::TransformStamped msg;
+    msg.transform = tf2::toMsg(map_to_odom);
+    msg.child_frame_id = m_odom_frame_id;
+    msg.header.frame_id = m_map_frame_id;
+    msg.header.stamp = imageTimestamp + m_transform_tolerance;
+
+
+    RCLCPP_DEBUG(get_logger(), "Sending out new transform %f %f %f rot %f %f %f %f",
+               msg.transform.translation.x,
+                msg.transform.translation.y,
+                msg.transform.translation.z,
+                msg.transform.rotation.w,
+                msg.transform.rotation.x,
+                msg.transform.rotation.y,
+                msg.transform.rotation.z);
+
+    m_lastTransform = msg;
+
+    m_tfBroadcaster->sendTransform(msg);
+}
+
+bool LpBaseNode::make_openvslam_config(const sensor_msgs::msg::CameraInfo::SharedPtr msg)
+{
+    // Form OpenVSLAM config YAML
+    YAML::Node configNode;
+
+    if (msg->distortion_model != "plumb_bob") {
+        RCLCPP_ERROR(
+            get_logger(),
+            "%s distortion model is not supported",
+            msg->distortion_model.c_str());
+        return false;
+    }
+
+    configNode["Camera"]["name"] = "LpSlam";
+    if (m_isStereoCamera)
+    {
+        configNode["Camera"]["setup"] = "stereo";
+    } else {
+        configNode["Camera"]["setup"] = "monocular";
+    }
+    configNode["Camera"]["model"] = "perspective";
+
+    configNode["Camera"]["fx"] = msg->k[0];  // k[0,0]
+    configNode["Camera"]["fy"] = msg->k[4];  // k[1,1]
+    configNode["Camera"]["cx"] = msg->k[2];  // k[0,2]
+    configNode["Camera"]["cy"] = msg->k[5];  // k[1,2]
+
+    // For perspective model
+    configNode["Camera"]["k1"] = 0.0;
+    configNode["Camera"]["k2"] = 0.0;
+    configNode["Camera"]["k3"] = 0.0;
+    configNode["Camera"]["p1"] = 0.0;
+    configNode["Camera"]["p2"] = 0.0;
+
+    if (m_isStereoCamera) {
+        configNode["Camera"]["focal_x_baseline"] = -msg->p[3];  // -p[0,3]
+    }
+
+    configNode["Camera"]["fps"] = m_cameraFps;
+    configNode["Camera"]["cols"] = msg->width;
+    configNode["Camera"]["rows"] = msg->height;
+
+    // Trying to get Camera.color_order
+    if (!get_camera_color_order(configNode)) {
+        return false;
+    }
+
+    configNode["Feature"]["max_num_keypoints"] = m_openVSlam_maxNumKeypoints;
+    configNode["Feature"]["ini_max_num_keypoints"] = m_openVSlam_iniMaxNumKeypoints;
+    configNode["Feature"]["scale_factor"] = m_openVSlam_scaleFactor;
+    configNode["Feature"]["num_levels"] = m_openVSlam_numLevels;
+    configNode["Feature"]["ini_fast_threshold"] = m_openVSlam_iniFastThreshold;
+    configNode["Feature"]["min_fast_threshold"] = m_openVSlam_minFastThreshold;
+
+    configNode["depth_threshold"] = m_openVSlam_depthThreshold;
+    configNode["depthmap_factor"] = m_openVSlam_depthmapFactor;
+
+    configNode["Mapping"]["baseline_dist_thr"] = m_openVSlam_mappingBaselineDistThr;
+
+    configNode["PangolinViewer"]["fps"] = m_openVSlam_pangolinViewerFps;
+
+    // Write formed YAML to file
+    m_openVSlamYaml = std::tmpnam(nullptr);
+    m_openVSlamYaml += ".yaml";
+    try {
+        std::ofstream yaml(m_openVSlamYaml);
+        yaml << configNode << std::endl;
+        yaml.close();
+    } catch (std::exception & e) {
+        RCLCPP_ERROR(
+            get_logger(), "Can not write OpenVSLAM config to %s: %s",
+            m_openVSlamYaml.c_str(), e.what());
+        return false;
+    }
+    RCLCPP_INFO(get_logger(), "%s OpenVSLAM config has been prepared", m_openVSlamYaml.c_str());
+    return true;
+}
+
+bool LpBaseNode::get_camera_color_order(YAML::Node & configNode)
+{
+    const int max_try = 10;
+    const int wait_ms = 200;
+
+    for (int c = 0; c < max_try; c++) {
+        const std::string camera_encoding = getCameraEncoding();
+        if (!camera_encoding.empty()) {
+            if (camera_encoding == sensor_msgs::image_encodings::RGB8) {
+                configNode["Camera"]["color_order"] = "RGB";
+                return true;
+            } else if (camera_encoding == sensor_msgs::image_encodings::RGBA8) {
+                configNode["Camera"]["color_order"] = "RGBA";
+                return true;
+            } else if (camera_encoding == sensor_msgs::image_encodings::BGR8) {
+                configNode["Camera"]["color_order"] = "BGR";
+                return true;
+            } else if (camera_encoding == sensor_msgs::image_encodings::BGRA8) {
+                configNode["Camera"]["color_order"] = "BGRA";
+                return true;
+            } else if (camera_encoding == sensor_msgs::image_encodings::MONO8) {
+                configNode["Camera"]["color_order"] = "Gray";
+                return true;
+            } else {
+                RCLCPP_ERROR(
+                    get_logger(),
+                    "%s camera encoding is not supported by OpenVSLAM",
+                    camera_encoding.c_str());
+                return false;
+            }
+        }
+        // Wait for some time
+        std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
+    }
+
+    RCLCPP_WARN(get_logger(), "Can not obtain camera encoding within %i ms", wait_ms * max_try);
+    return false;
+}
+
+LpSlamGlobalStateInTime LpBaseNode::transformToLpSlamGlobalState(geometry_msgs::msg::TransformStamped const& tf) const
+{
+    LpSlamGlobalStateInTime ros_state;
+    // ignored by LpSlam at the moment
+    ros_state.timestamp = 0;
+    ros_state.state.position = {tf.transform.translation.z,
+        -tf.transform.translation.y,
+        tf.transform.translation.x,
+        0.1, 0.1, 0.1};
+
+    const auto qRot = tf2::Quaternion(tf.transform.rotation.x,
+        tf.transform.rotation.y,
+        tf.transform.rotation.z,
+        tf.transform.rotation.w);
+
+    // LpSlam Convention needs an inverted quaternion
+    const auto invRot = qRot.inverse();
+
+    ros_state.state.orientation = {invRot.w(),
+        invRot.z(),
+        -invRot.y(),
+        invRot.x(), 0.1};
+
+    ros_state.state.valid = true;
+
+    return ros_state;
+}
+
+rclcpp::Time LpBaseNode::lpSlamToRosTime( LpSlamROSTimestamp const& ts ) const
+{
+    // note: need to use the constructor with just nanoseconds because
+    // it can use int64, the one taking seconds and nanosconds only takes
+    // int32 nanoseconds, therefore cutting off large entries of
+    // nano seconds
+    return rclcpp::Time(ts.nanoseconds + ts.seconds * std::pow(10,9));
+}
+
+LpSlamROSTimestamp LpBaseNode::rosTimeToLpSlam( rclcpp::Time const& ts ) const
+{
+    return LpSlamROSTimestamp{0, ts.nanoseconds()};
+}

--- a/src/LpBaseNode.hpp
+++ b/src/LpBaseNode.hpp
@@ -1,0 +1,186 @@
+// Copyright (C) 2021 LP-Research Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LP_BASE_NODE_HPP_
+#define LP_BASE_NODE_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sensor_msgs/msg/point_field.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <geometry_msgs/msg/transform_stamped.h>
+#include <geometry_msgs/msg/pose_stamped.h>
+
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <nav_msgs/msg/map_meta_data.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+#include <optional>
+#include <mutex>
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+#include <yaml-cpp/yaml.h>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/create_timer_ros.h>
+
+#include "LpSlamTypes.h"
+
+/*
+nice explainer:
+https://www.stereolabs.com/docs/ros2/video/
+*/
+
+class LpBaseNode : public rclcpp::Node
+{
+public:
+    LpBaseNode();
+
+private:
+    bool setParameters();
+    void initTransforms();
+
+public:
+    // Sends map->odom transform
+    void lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &state_in_time);
+    // Gets transform state between from_frame->to_frame
+    LpSlamRequestNavTransformation lpslam_RequestNavTransformationCallback(LpSlamROSTimestamp ros_time,
+        LpSlamNavDataFrame from_frame,
+        LpSlamNavDataFrame to_frame);
+    // Tries to get camera pose state in odom and map frames
+    LpSlamRequestNavDataResult lpslam_RequestNavDataCallback(LpSlamROSTimestamp for_ros_time,
+        LpSlamGlobalStateInTime * odometry,
+        LpSlamGlobalStateInTime * map );
+
+private:
+    void computeAndPublishTransform(LpSlamGlobalStateInTime const & state_in_time);
+
+protected:
+    // Config makers
+    bool make_openvslam_config(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
+    bool get_camera_color_order(YAML::Node & configNode);
+
+    // ROS<->LP converters
+    LpSlamGlobalStateInTime transformToLpSlamGlobalState(geometry_msgs::msg::TransformStamped const& tf) const;
+    rclcpp::Time lpSlamToRosTime( LpSlamROSTimestamp const& ts ) const;
+    LpSlamROSTimestamp rosTimeToLpSlam( rclcpp::Time const& ts ) const;
+
+    // TF2 handlers
+    std::shared_ptr<tf2_ros::TransformListener> m_tfListener;
+    std::shared_ptr<tf2_ros::Buffer> m_tfBuffer;
+    std::shared_ptr<tf2_ros::TransformBroadcaster> m_tfBroadcaster;
+
+    // frame ids
+    std::string m_map_frame_id;
+    std::string m_camera_frame_id;
+    std::string m_odom_frame_id;
+    std::string m_laserscan_frame_id;
+    std::string m_base_frame_id;
+
+    // Last map->odom transform
+    std::optional<geometry_msgs::msg::TransformStamped> m_lastTransform;
+
+    // configuration variables
+    bool m_useOdometry;
+    bool m_consumeLaser;
+    bool m_isStereoCamera;
+    // means that both stereo images are in one physical image
+    // transferred via the ROS topic left_image_raw
+    bool m_isCombinedStereoImage;
+    std::string m_qosReliability;
+    std::string m_laserscanTopic;
+    std::string m_leftImageTopic;
+    std::string m_rightImageTopic;
+    std::string m_cameraInfoTopic;
+    double m_cameraFps;
+    std::string m_pointcloudTopic;
+    int m_pointcloudRate;
+    std::string m_mapName;
+    int m_mapRate;
+    tf2::Duration m_transform_tolerance;
+
+    // VSLAM method selection (currently OpenVSLAM supported)
+    std::string m_vSlamMethod;
+
+    // OpenVSLAM parameters
+    int m_openVSlam_maxNumKeypoints;
+    int m_openVSlam_iniMaxNumKeypoints;
+    double m_openVSlam_scaleFactor;
+    int m_openVSlam_numLevels;
+    int m_openVSlam_iniFastThreshold;
+    int m_openVSlam_minFastThreshold;
+    double m_openVSlam_depthThreshold;
+    double m_openVSlam_depthmapFactor;
+    double m_openVSlam_mappingBaselineDistThr;
+    double m_openVSlam_pangolinViewerFps;
+
+    // Configuration file for OpenVSLAM
+    std::string m_openVSlamYaml;
+    // whether the camera config was read
+    bool m_cameraConfigured;
+
+private:
+    // Indicator that SLAM has been started and one can use its outputs
+    // (such as Map and PointClounds)
+    bool m_slamStarted;
+    std::mutex m_slamStartedMutex;
+
+    // Camera color encoding OpenVSLAM parameter
+    std::string m_openVSlam_cameraEncoding;
+    std::mutex m_openVSlam_cameraEncodingMutex;
+
+protected:
+    // Thread-safe methods
+    inline void setSlamStarted(const bool slam_started)
+    {
+        std::lock_guard<std::mutex> lock(m_slamStartedMutex);
+        m_slamStarted = slam_started;
+    }
+
+    inline bool isSlamStarted()
+    {
+        std::lock_guard<std::mutex> lock(m_slamStartedMutex);
+        return m_slamStarted;
+    }
+
+    inline void setCameraEncoding(const std::string & camera_encoding)
+    {
+        std::lock_guard<std::mutex> lock(m_openVSlam_cameraEncodingMutex);
+        m_openVSlam_cameraEncoding = camera_encoding;
+    }
+
+    inline std::string getCameraEncoding()
+    {
+        std::lock_guard<std::mutex> lock(m_openVSlam_cameraEncodingMutex);
+        return m_openVSlam_cameraEncoding;
+    }
+};
+
+#endif  // LP_BASE_NODE_HPP_

--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -1,1069 +1,18 @@
-//===========================================================================//
-//
 // Copyright (C) 2021 LP-Research Inc.
 //
-//===========================================================================//
-
-#include "rclcpp/rclcpp.hpp"
-
-#include <sensor_msgs/msg/image.hpp>
-#include <sensor_msgs/msg/camera_info.hpp>
-#include <sensor_msgs/image_encodings.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <sensor_msgs/msg/point_field.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-#include <geometry_msgs/msg/transform_stamped.h>
-#include <geometry_msgs/msg/pose_stamped.h>
-#include <geometry_msgs/msg/pose_stamped.h>
-#include <nav_msgs/msg/occupancy_grid.hpp>
-#include <nav_msgs/msg/map_meta_data.hpp>
-#include <lpslam_interfaces/msg/lp_slam_status.hpp>
-
-
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-
-#include "LpSlamManager.h"
-
-#include <cstring>
-#include <memory>
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <cstdio>
-#include <optional>
-#include <mutex>
-#include <algorithm>
-#include <chrono>
-#include <thread>
-
-#include <yaml-cpp/yaml.h>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
-#include <tf2_ros/create_timer_ros.h>
-
-/*
-nice explainer:
-https://www.stereolabs.com/docs/ros2/video/
-*/
-
-void outside_lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &state_in_time, void *lpslam_object);
-
-LpSlamRequestNavDataResult outside_lpslam_RequestNavDataCallback(LpSlamROSTimestamp for_ros_time,
-    LpSlamGlobalStateInTime * odometry,
-    LpSlamGlobalStateInTime * map,
-    void *);
-
-LpSlamRequestNavTransformation outside_lpslam_RequestNavTransformationCallback(LpSlamROSTimestamp ros_time,
-    LpSlamNavDataFrame from_frame,
-    LpSlamNavDataFrame to_frame,
-    void * lpslam_node);
-
-class LpSlamNode : public rclcpp::Node
-{
-public:
-    LpSlamNode() : Node("lpslam_node")
-    {
-        RCLCPP_INFO(get_logger(), "LpSlam node started");
-
-        m_vSlamMethod = "OpenVSLAM";
-
-        m_configFile = this->declare_parameter<std::string>("lpslam_config", "");
-        m_lpSlamLogFile = this->declare_parameter<std::string>("lpslam_log_file", "lpslam.log");
-        m_writeLpSlamLog = this->declare_parameter<bool>("write_lpslam_log", false);
-        m_isStereoCamera = this->declare_parameter<bool>("stereo_camera", true);
-        m_consumeLaser = this->declare_parameter<bool>("consume_laser", true);
-        m_isCombinedStereoImage = this->declare_parameter<bool>("combined_stereo_image", false);
-        m_timespanMatch = this->declare_parameter<double>("timespan_match", 0.010); // 10 ms mach distance
-        m_map_frame_id = this->declare_parameter<std::string>("map_frame_id", "map");
-        m_camera_frame_id = this->declare_parameter<std::string>("camera_frame_id", "camera_link");
-        m_odom_frame_id = this->declare_parameter<std::string>("odom_frame_id", "odom");
-        m_base_frame_id = this->declare_parameter<std::string>("base_frame_id", "base_link");
-        m_laserscan_frame_id = this->declare_parameter<std::string>("laserscan_frame_id", "laser");
-
-        auto useSimTime = this->get_parameter( "use_sim_time" ).as_bool();
-        RCLCPP_INFO(get_logger(), "LpSlamNode is using sim time: %s", useSimTime ? "yes": "no");
-
-        const std::string left_image_topic = this->declare_parameter<std::string>(
-            "left_image_topic", "left_image_raw");
-        const std::string right_image_topic = this->declare_parameter<std::string>(
-            "right_image_topic", "right_image_raw");
-        const std::string camera_info_topic = this->declare_parameter<std::string>(
-            "camera_info_topic", "");
-        m_cameraFps = this->declare_parameter<double>("camera_fps", 5.0);
-        const auto map_name = this->declare_parameter<std::string>("map_name", "/map");
-        const std::string laserscan_topic = this->declare_parameter<std::string>("laserscan_topic", "scan");
-
-        const std::string pointcloud_topic = this->declare_parameter<std::string>("pointcloud_topic", "slam_features");
-        const auto pointcloud_rate = this->declare_parameter<int>("pointcloud_rate", 10);
-        const auto map_rate = this->declare_parameter<int>("map_rate", 5);
-
-        const std::string lpslam_status_topic = this->declare_parameter<std::string>(
-            "lpslam_status_topic", "lpslam_status");
-
-        // OpenVSLAM parameters
-        m_openVSlam_maxNumKeypoints = this->declare_parameter<int>(
-            m_vSlamMethod + "." + "max_num_keypoints", 1000);
-        m_openVSlam_iniMaxNumKeypoints = this->declare_parameter<int>(
-            m_vSlamMethod + "." + "ini_max_num_keypoints", 2000);
-        m_openVSlam_scaleFactor = this->declare_parameter<double>(
-            m_vSlamMethod + "." + "scale_factor", 1.2);
-        m_openVSlam_numLevels = this->declare_parameter<int>(
-            m_vSlamMethod + "." + "num_levels", 8);
-        m_openVSlam_iniFastThreshold = this->declare_parameter<int>(
-            m_vSlamMethod + "." + "ini_fast_threshold", 20);
-        m_openVSlam_minFastThreshold = this->declare_parameter<int>(
-            m_vSlamMethod + "." + "min_fast_threshold", 7);
-        m_openVSlam_depthThreshold = this->declare_parameter<double>(
-            m_vSlamMethod + "." + "depth_threshold", 40.0);
-        m_openVSlam_depthmapFactor = this->declare_parameter<double>(
-            m_vSlamMethod + "." + "depthmap_factor", 1.0);
-        m_openVSlam_mappingBaselineDistThr = this->declare_parameter<double>(
-            m_vSlamMethod + "." + "mapping_baseline_dist_thr", 0.1);
-        m_openVSlam_pangolinViewerFps  = this->declare_parameter<double>(
-            m_vSlamMethod + "." + "pangolin_viewer_fps", 10.0);
-
-        m_openVSlamYaml = "";
-        m_lpSlamJson = m_configFile;
-        m_cameraConfigured = false;
-        m_cameraEncoding = "";
-
-        m_use_odometry = this->declare_parameter<bool>("use_odometry", true);
-
-        const auto transformToleranceFloat = this->declare_parameter<float>("transform_tolerance", 0.5);
-        m_transform_tolerance = tf2::durationFromSec(transformToleranceFloat);
-
-        initTransforms();
-
-        // allow for relaxed QoS for laser scan in order to match
-        // the topic settings
-        rclcpp::QoS laser_qos(5);
-        laser_qos.keep_last(5);
-        laser_qos.best_effort();
-        laser_qos.durability_volatile();
-
-        auto default_qos = rclcpp::QoS(rclcpp::SystemDefaultsQoS());
-        
-        if (m_consumeLaser) { 
-            m_laserScanSubsription = this->create_subscription<sensor_msgs::msg::LaserScan>(
-                laserscan_topic, default_qos,
-                std::bind(&LpSlamNode::laserscan_callback, this, std::placeholders::_1));
-        }
-
-        // allow for relaxed QoS for image in order to match
-        // the topic settings
-        rclcpp::QoS video_qos(10);
-        video_qos.keep_last(10);
-        video_qos.best_effort();
-        video_qos.durability_volatile();
-
-        m_leftImageSubscription = this->create_subscription<sensor_msgs::msg::Image>(
-            left_image_topic, video_qos,
-            std::bind(&LpSlamNode::image_callback_left, this, std::placeholders::_1));
-
-        if (m_isStereoCamera && !m_isCombinedStereoImage)
-        {
-            m_rightImageSubscription = this->create_subscription<sensor_msgs::msg::Image>(
-                right_image_topic, video_qos,
-                std::bind(&LpSlamNode::image_callback_right, this, std::placeholders::_1));
-        }
-
-        if (!camera_info_topic.empty())
-        {
-            m_cameraInfoSubscription = this->create_subscription<sensor_msgs::msg::CameraInfo>(
-                camera_info_topic, video_qos,
-                std::bind(&LpSlamNode::camera_info_callback, this, std::placeholders::_1));
-        }
-
-        m_pointcloudPublisher = this->create_publisher<sensor_msgs::msg::PointCloud2>(pointcloud_topic, 1);
-
-        m_occGridPublisher = this->create_publisher<nav_msgs::msg::OccupancyGrid>(map_name,
-            rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
-        m_mapMetaDataPublisher = this->create_publisher<nav_msgs::msg::MapMetaData>(map_name + "_metadata",
-            rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
-        m_slamStatusPublisher = this->create_publisher<lpslam_interfaces::msg::LpSlamStatus>(
-            lpslam_status_topic,
-            rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
-
-        m_tfBroadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(this);
-
-        if (camera_info_topic.empty()) {
-            // Camera calibration files won't be read from topic.
-            // Starting SLAM manually.
-            start_slam();
-        }
-
-        // start publishing point cloud
-        auto ros_clock = rclcpp::Clock::make_shared();
-        m_pointcloud_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(pointcloud_rate, 0),
-                                                  [this]() {
-                                                      this->publishPointCloud();
-                                                  });
-        m_occmap_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(map_rate, 0),
-                                                  [this]() {
-                                                      this->publishOccMap();
-                                                  });
-
-        m_slamstatus_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(1, 0),
-                                                  [this]() {
-                                                      const auto state = this->m_slam.getSlamStatus();
-
-                                                      lpslam_interfaces::msg::LpSlamStatus ros_state;
-
-                                                        ros_state.localization_status = 0;
-                                                        if (state.localization == LpSlamLocalization_Off) {
-                                                            ros_state.localization_status = 0;
-                                                        } else if (state.localization == LpSlamLocalization_Initializing) {
-                                                            ros_state.localization_status = 1;
-                                                        } else if (state.localization == LpSlamLocalization_Tracking) {
-                                                            ros_state.localization_status = 2;
-                                                        } else if (state.localization == LpSlamLocalization_Lost) {
-                                                            ros_state.localization_status = 3;
-                                                        }
-
-                                                      ros_state.feature_points = state.feature_points;
-                                                      ros_state.key_frames = state.key_frames;
-                                                      ros_state.frame_time = state.frame_time;
-                                                      ros_state.fps = state.fps;
-
-                                                      this->m_slamStatusPublisher->publish(std::move(ros_state));
-                                                  });
-    }
-
-    virtual ~LpSlamNode()
-    {
-        RCLCPP_INFO(get_logger(), "shutting down LpSlam");
-        m_pointcloud_timer.reset();
-        m_occmap_timer.reset();
-        m_slamstatus_timer.reset();
-        m_slam.stop();
-        RCLCPP_INFO(get_logger(), "shutting down LpSlam complete");
-    }
-
-private:
-
-    void start_slam()
-    {
-        if (m_writeLpSlamLog)
-        {
-            m_slam.logToFile(m_lpSlamLogFile.c_str());
-        }
-        m_slam.setLogLevel(LpSlamLogLevel_Debug);
-        RCLCPP_INFO_STREAM(get_logger(), "Loading LpSlam configuration from " << m_lpSlamJson);
-        m_slam.readConfigurationFile(m_lpSlamJson.c_str());
-
-        m_slam.addOnReconstructionCallback(&outside_lpslam_OnReconstructionCallback, this);
-        m_slam.addRequestNavTransformation(&outside_lpslam_RequestNavTransformationCallback, this);
-        if (m_use_odometry) {
-            m_slam.addRequestNavDataCallback(&outside_lpslam_RequestNavDataCallback, this);
-        }
-
-        m_slam.start();
-        RCLCPP_INFO(get_logger(), "LpSlam processing starting");
-    }
-
-    // according to https://github.com/ros2/common_interfaces/blob/master/nav_msgs/msg/OccupancyGrid.msg
-    // http://docs.ros.org/en/api/nav_msgs/html/msg/MapMetaData.html
-    void publishOccMap()
-    {
-        if (m_occGridPublisher->get_subscription_count() == 0) {
-            return;
-        }
-
-        RCLCPP_DEBUG(get_logger(), "Start publishing occupancy map");
-        const auto rawSizeNeeded = m_slam.mappingGetMapRawSize();
-
-        nav_msgs::msg::OccupancyGrid occGridMessage;
-        occGridMessage.data.resize(rawSizeNeeded);
-
-        const auto mapInfo = m_slam.mappingGetMapRaw(occGridMessage.data.data(), occGridMessage.data.size());
-        const auto exportCount = mapInfo.y_cell_count * mapInfo.x_cell_count;
-        RCLCPP_DEBUG(get_logger(), "exported %u occupancy map points", exportCount);
-
-        occGridMessage.info.height = mapInfo.y_cell_count;
-        occGridMessage.info.width = mapInfo.x_cell_count;
-        occGridMessage.info.resolution = mapInfo.x_cell_size;
-        occGridMessage.info.origin.position.x = mapInfo.x_origin;
-        occGridMessage.info.origin.position.y = mapInfo.y_origin;
-
-        RCLCPP_DEBUG(get_logger(), "occupancy map origin (%f, %f)", occGridMessage.info.origin.position.x,
-            occGridMessage.info.origin.position.y);
-
-        //  account for higher placement of camera
-        occGridMessage.info.origin.position.z = -1.15;
-
-        occGridMessage.header.frame_id = m_map_frame_id;
-        occGridMessage.header.stamp = this->now();
-
-        m_occGridPublisher->publish(std::move(occGridMessage));
-        m_mapMetaDataPublisher->publish(std::move(occGridMessage.info));
-        RCLCPP_DEBUG(get_logger(), "Finished publishing occupancy map");
-    }
-
-    void publishPointCloud()
-    {
-        if (m_pointcloudPublisher->get_subscription_count() == 0) {
-            return;
-        }
-
-        RCLCPP_DEBUG(get_logger(), "Starting to publish feature points");
-
-        // ignored by the API anyways
-        LpSlamMapBoundary bounds;
-        auto featureSize = m_slam.mappingGetFeaturesCount(bounds);
-
-        // limit the max points for now
-        featureSize = std::min(featureSize, std::size_t(50000));
-        m_featurePointBuffer.resize(featureSize);
-
-        // transform from LpSlam coords to ROS
-        //transformation lpslam -> ROS is
-        // z_ros = x_lpslam
-        // x_ros = z_lpslam
-        // y_ros = -y_lpslam
-
-        LpSlamMatrix9x9 lpslam_to_ros = {
-            0.0,  0.0,  1.0,
-            0.0, -1.0,  0.0,
-            1.0,  0.0,  0.0
-        };
-
-        auto outputSize = m_slam.mappingGetFeatures(bounds, m_featurePointBuffer.data(),
-                                                   featureSize, lpslam_to_ros);
-
-        RCLCPP_DEBUG_STREAM(get_logger(), "Streaming out " << outputSize << " feature points");
-        m_featurePointBuffer.resize(outputSize);
-
-        // from https://github.com/ros/common_msgs/blob/jade-devel/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
-
-        // Create a PointCloud2
-        auto cloud_msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
-        // Fill some internals of the PoinCloud2 like the header/width/height ...
-        cloud_msg->header.frame_id = m_map_frame_id;
-        cloud_msg->header.stamp = this->now();
-
-        cloud_msg->height = 1;
-        cloud_msg->width = 3;
-        // Set the point fields to xyzrgb and resize the vector with the following command
-        // 4 is for the number of added fields. Each come in triplet: the name of the PointField,
-        // the number of occurrences of the type in the PointField, the type of the PointField
-        sensor_msgs::PointCloud2Modifier modifier(*cloud_msg.get());
-        modifier.setPointCloud2Fields(3, "x", 1, sensor_msgs::msg::PointField::FLOAT32,
-                                      "y", 1, sensor_msgs::msg::PointField::FLOAT32,
-                                      "z", 1, sensor_msgs::msg::PointField::FLOAT32);
-        // For convenience and the xyz, rgb, rgba fields, you can also use the following overloaded function.
-        // You have to be aware that the following function does add extra padding for backward compatibility though
-        // so it is definitely the solution of choice for PointXYZ and PointXYZRGB
-        // 2 is for the number of fields to add
-        //modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
-        // You can then reserve / resize as usual
-        modifier.resize(outputSize);
-
-        cloud_msg->is_bigendian = false;
-        cloud_msg->is_dense = false;
-
-        // can do that because the LpSlam structure has exactly three floats
-        // might change in the future
-        if (sizeof(LpSlamFeatureEntry) != (sizeof(float) * 3))
-        {
-            RCLCPP_ERROR(get_logger(), "Assumption about LpSlamFeatureEntry struct size not correct");
-            return;
-        }
-
-        float* cloud_msg_ptr = (float*)(&cloud_msg->data[0]);
-        std::memcpy(cloud_msg_ptr, (float*)m_featurePointBuffer.data(), outputSize * sizeof(LpSlamFeatureEntry));
-
-        m_pointcloudPublisher->publish(std::move(cloud_msg));
-        RCLCPP_DEBUG(get_logger(), "Finished publishing feature points");
-    }
-
-private:
-    void initTransforms()
-    {
-        // Initialize transform listener and broadcaster
-        m_tfBuffer = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-        auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-            this->get_node_base_interface(),
-            this->get_node_timers_interface());
-        m_tfBuffer->setCreateTimerInterface(timer_interface);
-        m_tfListener = std::make_shared<tf2_ros::TransformListener>(*m_tfBuffer);
-        m_tfBroadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(this);
-    }
-
-    bool check_and_dispatch(const sensor_msgs::msg::Image::SharedPtr this_msg,
-                            std::vector<uint8_t> &otherImageBuffer, std::optional<builtin_interfaces::msg::Time> &otherTimestamp,
-                            std::mutex &otherMutex,
-                            bool isLeft)
-    {
-        std::scoped_lock lock(otherMutex);
-
-        // is the cached image close in time what we already got ?
-        if (!otherTimestamp.has_value())
-        {
-            return false;
-        }
-
-        uint64_t diff_seconds = otherTimestamp->sec - this_msg->header.stamp.sec;
-        uint64_t diff_nanoseconds = otherTimestamp->nanosec - this_msg->header.stamp.nanosec;
-
-        double dt = diff_seconds + std::pow(10, -9) * double(diff_nanoseconds);
-
-        if (std::abs(dt) > m_timespanMatch)
-        {
-            return false;
-        }
-
-        // dispatch both images
-        LpSlamImageDescription imgDesc;
-        imgDesc.structure = LpSlamImageStructure_Stereo_TwoBuffer;
-        if (this_msg->encoding == "mono8" ) {
-            imgDesc.format = LpSlamImageFormat_8UC1;
-        } else {
-            imgDesc.format = LpSlamImageFormat_8UC3;
-        }
-        imgDesc.image_conversion = LpSlamImageConversion_None;
-        imgDesc.height = this_msg->height;
-        imgDesc.width = this_msg->width;
-        imgDesc.imageSize = this_msg->step * this_msg->height;
-        imgDesc.hasRosTimestamp = 1;
-        imgDesc.rosTimestamp.seconds = this_msg->header.stamp.sec;
-        imgDesc.rosTimestamp.nanoseconds = this_msg->header.stamp.nanosec;
-
-        // slam timestamp
-        uint64_t slam_ts = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-
-        // forward to library
-        m_slam.addStereoImageFromBuffer(0,
-                                        // timestamp
-                                        slam_ts,
-                                        isLeft ? this_msg->data.data() : otherImageBuffer.data(),
-                                        isLeft ? otherImageBuffer.data() : this_msg->data.data(),
-                                        imgDesc);
-        otherTimestamp.reset();
-        return true;
-    }
-
-    bool get_camera_color_order(YAML::Node & configNode)
-    {
-        const int max_try = 10;
-        for (int c = 0; c < max_try; c++) {
-            {
-                std::lock_guard<std::mutex> lock(m_cameraEncodingMutex);
-                if (!m_cameraEncoding.empty()) {
-                    if (m_cameraEncoding == sensor_msgs::image_encodings::RGB8) {
-                        configNode["Camera"]["color_order"] = "RGB";
-                        return true;
-                    } else if (m_cameraEncoding == sensor_msgs::image_encodings::RGBA8) {
-                        configNode["Camera"]["color_order"] = "RGBA";
-                        return true;
-                    } else if (m_cameraEncoding == sensor_msgs::image_encodings::BGR8) {
-                        configNode["Camera"]["color_order"] = "BGR";
-                        return true;
-                    } else if (m_cameraEncoding == sensor_msgs::image_encodings::BGRA8) {
-                        configNode["Camera"]["color_order"] = "BGRA";
-                        return true;
-                    } else if (m_cameraEncoding == sensor_msgs::image_encodings::MONO8) {
-                        configNode["Camera"]["color_order"] = "Gray";
-                        return true;
-                    } else {
-                        RCLCPP_ERROR(
-                            get_logger(),
-                            "%s camera encoding is not supported by OpenVSLAM",
-                            m_cameraEncoding.c_str());
-                        return false;
-                    }
-                }
-            }
-            // Wait for some time
-            std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        }
-
-        RCLCPP_ERROR(get_logger(), "Can not obtain camera encoding");
-        return false;
-    }
-
-    bool make_openvslam_config(const sensor_msgs::msg::CameraInfo::SharedPtr msg)
-    {
-        // Form OpenVSLAM config YAML
-        YAML::Node configNode;
-
-        if (msg->distortion_model != "plumb_bob") {
-            RCLCPP_ERROR(
-                get_logger(),
-                "%s distortion model is not supported",
-                msg->distortion_model.c_str());
-            return false;
-        }
-
-        configNode["Camera"]["name"] = "LpSlam";
-        if (m_isStereoCamera)
-        {
-            configNode["Camera"]["setup"] = "stereo";
-        } else {
-            configNode["Camera"]["setup"] = "monocular";
-        }
-        configNode["Camera"]["model"] = "perspective";
-
-        configNode["Camera"]["fx"] = msg->k[0];  // k[0,0]
-        configNode["Camera"]["fy"] = msg->k[4];  // k[1,1]
-        configNode["Camera"]["cx"] = msg->k[2];  // k[0,2]
-        configNode["Camera"]["cy"] = msg->k[5];  // k[1,2]
-
-        // For perspective model
-        configNode["Camera"]["k1"] = 0.0;
-        configNode["Camera"]["k2"] = 0.0;
-        configNode["Camera"]["k3"] = 0.0;
-        configNode["Camera"]["p1"] = 0.0;
-        configNode["Camera"]["p2"] = 0.0;
-
-        if (m_isStereoCamera) {
-            configNode["Camera"]["focal_x_baseline"] = -msg->p[3];  // -p[0,3]
-        }
-
-        configNode["Camera"]["fps"] = m_cameraFps;
-        configNode["Camera"]["cols"] = msg->width;
-        configNode["Camera"]["rows"] = msg->height;
-
-        // Trying to get Camera.color_order
-        if (!get_camera_color_order(configNode)) {
-            return false;
-        }
-
-        configNode["Feature"]["max_num_keypoints"] = m_openVSlam_maxNumKeypoints;
-        configNode["Feature"]["ini_max_num_keypoints"] = m_openVSlam_iniMaxNumKeypoints;
-        configNode["Feature"]["scale_factor"] = m_openVSlam_scaleFactor;
-        configNode["Feature"]["num_levels"] = m_openVSlam_numLevels;
-        configNode["Feature"]["ini_fast_threshold"] = m_openVSlam_iniFastThreshold;
-        configNode["Feature"]["min_fast_threshold"] = m_openVSlam_minFastThreshold;
-
-        configNode["depth_threshold"] = m_openVSlam_depthThreshold;
-        configNode["depthmap_factor"] = m_openVSlam_depthmapFactor;
-
-        configNode["Mapping"]["baseline_dist_thr"] = m_openVSlam_mappingBaselineDistThr;
-
-        configNode["PangolinViewer"]["fps"] = m_openVSlam_pangolinViewerFps;
-
-        // Write formed YAML to file
-        m_openVSlamYaml = std::tmpnam(nullptr);
-        m_openVSlamYaml += ".yaml";
-        try {
-            std::ofstream yaml(m_openVSlamYaml);
-            yaml << configNode << std::endl;
-            yaml.close();
-        } catch (std::exception & e) {
-            RCLCPP_ERROR(
-                get_logger(), "Can not write OpenVSLAM config to %s: %s",
-                m_openVSlamYaml.c_str(), e.what());
-            return false;
-        }
-        RCLCPP_INFO(get_logger(), "%s OpenVSLAM config has been prepared", m_openVSlamYaml.c_str());
-        return true;
-    }
-
-    bool make_lpslam_config()
-    {
-        if (m_openVSlamYaml.length() == 0)
-        {
-            RCLCPP_ERROR(get_logger(), "No OpenVSLAM config-file prepared");
-            return false;
-        }
-
-        // Write formed YAML to file
-        m_lpSlamJson = std::tmpnam(nullptr);
-        m_lpSlamJson += ".json";
-        try {
-            // Open m_configFile for reading
-            std::ifstream in_json(m_configFile);
-            std::string ln;
-            // And m_lpSlamJson for writing
-            std::ofstream out_json(m_lpSlamJson);
-            size_t config_pos;
-            // Replace "configFromFile" field with m_openVSlamYaml
-            while (std::getline(in_json, ln))
-            {
-                config_pos = ln.find("configFromFile");
-                if (config_pos != std::string::npos)
-                {
-                    ln = ln.substr(0, config_pos) +
-                        "configFromFile\": \"" + m_openVSlamYaml + "\",";
-                }
-                out_json << ln << std::endl;
-            }
-            in_json.close();
-            out_json.close();
-        } catch (std::exception & e) {
-            RCLCPP_ERROR(
-                get_logger(), "Error while processing %s -> to %s: %s",
-                m_configFile.c_str(), m_lpSlamJson.c_str(), e.what());
-            return false;
-        }
-        RCLCPP_INFO(get_logger(), "%s LP-SLAM config has been prepared", m_lpSlamJson.c_str());
-        return true;
-    }
-
-    // Callbacks
-    void image_callback_right(const sensor_msgs::msg::Image::SharedPtr msg)
-    {
-        if (check_and_dispatch(msg, m_leftImageBuffer, m_leftImageTimestamp, m_leftImageMutex, false))
-        {
-            return;
-        }
-
-        {
-            std::scoped_lock lock(m_rightImageMutex);
-            m_rightImageBuffer.resize(msg->step * msg->height);
-            std::memcpy(m_rightImageBuffer.data(), msg->data.data(),
-                        m_rightImageBuffer.size());
-            m_rightImageTimestamp = msg->header.stamp;
-        }
-    }
-
-    void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg)
-    {
-        if (m_cameraConfigured)
-        {
-            return;
-        }
-
-        // Make OpenVSLAM config-file
-        if (!make_openvslam_config(msg))
-        {
-            return;
-        }
-        // Update LP-SLAM config file with prepared OpenVSLAM one
-        if (!make_lpslam_config())
-        {
-            return;
-        }
-
-        // All configurations were prepared. Starting SLAM.
-        start_slam();
-
-        // Once camera was configured, no more actions needed here
-        m_cameraConfigured = true;
-    }
-
-    void image_callback_left(const sensor_msgs::msg::Image::SharedPtr msg)
-    {
-        std::lock_guard<std::mutex> lock(m_cameraEncodingMutex);
-        if (m_cameraEncoding.empty()) {
-            m_cameraEncoding = msg->encoding;
-        }
-
-        if (check_and_dispatch(msg, m_rightImageBuffer, m_rightImageTimestamp, m_rightImageMutex, true))
-        {
-            return;
-        }
-        {
-            std::scoped_lock lock(m_leftImageMutex);
-            m_leftImageBuffer.resize(msg->step * msg->height);
-            std::memcpy(m_leftImageBuffer.data(), msg->data.data(),
-                        m_leftImageBuffer.size());
-            m_leftImageTimestamp = msg->header.stamp;
-        }
-    }
-
-    void laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
-    {
-        // This can be used to transform laser scan into camera frame
-        // http://docs.ros.org/en/latest/api/tf2_ros/html/c++/classtf2__ros_1_1BufferInterface.html#a12d0bda7d7533f199e94dae4bb46ba7a
-        // Use this method to lookup the transform of the laser data at time t_l to the camera pose at t_c
-
-        RCLCPP_DEBUG(get_logger(), "Received %lu laser scans with min %f max %f angle start %f angle end %f",
-            msg->ranges.size(), msg->range_min, msg->range_max, msg->angle_min, msg->angle_max);
-
-        // wait up to 100 ms for transform to arrive, parameter is nanoseconds
-        auto transformTimeout = rclcpp::Duration::from_nanoseconds(0.1 * std::pow(10.0, 9.0));
-
-        std::optional<geometry_msgs::msg::TransformStamped> odomTransform;
-        try {
-            // first: target frame
-            // second: source frame
-            // get the transformation for the laser scan's time, get odometry frame
-            // because this information is not really used by LPSLAM and its always available,
-            // in contrast to map frame transform
-            odomTransform = m_tfBuffer->lookupTransform(m_odom_frame_id, m_laserscan_frame_id,
-                msg->header.stamp, transformTimeout);
-        } catch (tf2::LookupException &ex) {
-            RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
-            return;
-        } catch (tf2::ConnectivityException &ex) {
-            RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
-            return;
-        } catch (tf2::ExtrapolationException &ex) {
-            RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
-            return;
-        } catch (tf2::InvalidArgumentException &ex) {
-            RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
-            return;
-        }
-
-        auto lpstate = transformToLpSlamGlobalState(odomTransform.value());
-        lpstate.has_ros_timestamp = true;
-        lpstate.ros_timestamp = rosTimeToLpSlam(msg->header.stamp);
-        
-        // use the odomtry transform to get the global coordinates because its more reliable and faster
-        // than the pure optical measurement
-        // LaserScan data is obviously in laser frame
-        m_slam.mappingAddLaserScan(lpstate, msg->ranges.data(), msg->ranges.size(),
-            msg->range_min, msg->range_max,
-            msg->angle_min, msg->angle_max,
-            msg->angle_increment, 3.0);
-        RCLCPP_DEBUG(get_logger(), "Laser data dispatched");
-    }
-
-public:
-    // needs to be public because its called from the outside
-    void lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &state_in_time)
-    {
-        //transformation lpslam -> ROS is
-        // z_ros = x_lpslam
-        // x_ros = z_lpslam
-        // y_ros = -y_lpslam
-
-        auto const &state = state_in_time.state;
-
-        if (!state.valid)  {
-            RCLCPP_DEBUG(get_logger(), "SLAM Tracking state invalid, wont use it.");
-
-               // send out the last transform we know
-            if (m_lastTransform.has_value())  {
-                auto msg = m_lastTransform.value();
-                msg.header.stamp = this->now() + m_transform_tolerance;
-                m_tfBroadcaster->sendTransform(msg);
-                RCLCPP_INFO(get_logger(), "Send out old transform because new one does not exist.");
-            }
-            return;
-        }
-
-        // subtracting base to odom from map to base and send map to odom instead
-        geometry_msgs::msg::PoseStamped odom_to_map;
-        tf2::Transform new_tf;
-        tf2::TimePoint transform_expiration;
-
-        // relevant lines:
-        // https://github.com/SteveMacenski/slam_toolbox/blob/foxy-devel/src/slam_toolbox_common.cpp#L386
-        computeAndPublishTransform(state_in_time);
-    }
-
-    LpSlamRequestNavTransformation lpslam_RequestNavTransformationCallback(LpSlamROSTimestamp ros_time,
-        LpSlamNavDataFrame from_frame,
-        LpSlamNavDataFrame to_frame) {
-
-        LpSlamRequestNavTransformation invalid_res;
-        invalid_res.valid = false;
-
-        RCLCPP_DEBUG(get_logger(), "Requested nav transform for seconds %d nseconds %ld", ros_time.seconds, ros_time.nanoseconds);
-        
-        auto lmdMapName = [this](LpSlamNavDataFrame frame_enum )  {
-            if (frame_enum == LpSlamNavDataFrame_Camera) {
-                return m_camera_frame_id;
-            } else if (frame_enum == LpSlamNavDataFrame_Laser) {
-                return m_laserscan_frame_id;
-            } else if (frame_enum == LpSlamNavDataFrame_Odometry) {
-                return m_odom_frame_id;
-            } else {
-                return std::string("");
-            }
-        };
-
-        const auto transformTimeout = rclcpp::Duration::from_nanoseconds(0.1 * std::pow(10.0, 9.0));
-
-        std::optional<geometry_msgs::msg::TransformStamped> transform;
-        auto from_frame_id = lmdMapName(from_frame);
-        auto to_frame_id = lmdMapName(to_frame);
-
-        if (to_frame_id.empty() || from_frame_id.empty()) {
-            RCLCPP_ERROR(get_logger(), "LpSlam fram cannot be converted to ROS frame");
-            return invalid_res;
-        }
-
-        const auto cpp_ros_time = lpSlamRosTime(ros_time);
-
-        try {
-            transform = m_tfBuffer->lookupTransform(to_frame_id, from_frame_id, cpp_ros_time,
-                transformTimeout);
-        } catch (tf2::TransformException &ex) {
-            RCLCPP_ERROR(get_logger(), "Cannot get transformation for LpSlam Callback %s", ex.what());
-            return invalid_res;
-        }
-
-        const auto lpstate = transformToLpSlamGlobalState(transform.value());
-        return lpstate.state;
-    }
-
-    LpSlamRequestNavDataResult lpslam_RequestNavDataCallback(LpSlamROSTimestamp for_ros_time,
-        LpSlamGlobalStateInTime * odometry,
-        LpSlamGlobalStateInTime * map ) {
-
-        RCLCPP_DEBUG(get_logger(), "Requested nav data for time %i %lu", for_ros_time.seconds, for_ros_time.nanoseconds);
-
-        auto navTime = lpSlamRosTime(for_ros_time);
-
-        // wait up to 100 ms for transform to arrive, parameter is nanoseconds
-        auto transformTimeout = rclcpp::Duration::from_nanoseconds(0.1 * std::pow(10.0, 9.0));
-
-        std::optional<geometry_msgs::msg::TransformStamped> odomTransform;
-        try {
-            // first: target frame
-            // second: source frame
-            // lookup the full transformation all the way to the camera
-            // this will include the odometry transformation whichis the relevant part here !
-            // because the map -> odom transformation is quite stable over time this
-            // allows us to provide global position input, even if the tracking is lost
-            odomTransform = m_tfBuffer->lookupTransform(m_odom_frame_id, m_camera_frame_id, navTime,
-                transformTimeout);
-        } catch (tf2::TransformException &ex) {
-            RCLCPP_ERROR(get_logger(), "Cannot get odometry transformation: %s", ex.what());
-        }
-        
-        std::optional<geometry_msgs::msg::TransformStamped> mapTransform;
-        try {
-            // first: target frame
-            // second: source frame
-            // lookup the full transformation all the way to the camera
-            // this will include the odometry transformation whichis the relevant part here !
-            // because the map -> odom transformation is quite stable over time this
-            // allows us to provide global position input, even if the tracking is lost
-            mapTransform = m_tfBuffer->lookupTransform(m_map_frame_id, m_camera_frame_id, navTime,
-                transformTimeout);
-        } catch (tf2::TransformException &ex) {
-            RCLCPP_ERROR(get_logger(), "Cannot get map transformation: %s", ex.what());
-        }
-
-        // todo handle  case when there is no map transform
-        if (odomTransform.has_value()) {
-            RCLCPP_DEBUG(get_logger(), "odometry transformation to user: %f %f %f  Rot %f %f %f %f",
-                odomTransform->transform.translation.x,
-                odomTransform->transform.translation.y,
-                odomTransform->transform.translation.z,
-                odomTransform->transform.rotation.w,
-                odomTransform->transform.rotation.x,
-                odomTransform->transform.rotation.y,
-                odomTransform->transform.rotation.z);
-
-            *odometry = transformToLpSlamGlobalState(odomTransform.value());
-
-        }
-
-        // todo handle  case when there is no map transform
-        if (mapTransform.has_value()) {
-            RCLCPP_DEBUG(get_logger(), "map transformation to user: %f %f %f  Rot %f %f %f %f",
-                mapTransform->transform.translation.x,
-                mapTransform->transform.translation.y,
-                mapTransform->transform.translation.z,
-                mapTransform->transform.rotation.w,
-                mapTransform->transform.rotation.x,
-                mapTransform->transform.rotation.y,
-                mapTransform->transform.rotation.z);
-
-            *map = transformToLpSlamGlobalState(mapTransform.value());
-
-        }
-
-        if (mapTransform.has_value() && odomTransform.has_value()) {
-            return LpSlamRequestNavDataResult_OdomAndMap;
-        }
-
-        if (mapTransform.has_value() && !odomTransform.has_value()) {
-            return LpSlamRequestNavDataResult_MapOnly;
-        }
-
-        if (!mapTransform.has_value() && odomTransform.has_value()) {
-            return LpSlamRequestNavDataResult_OdomOnly;
-        }
-
-        // invalid odom
-        return LpSlamRequestNavDataResult_None;
-    }
-
-    void computeAndPublishTransform(LpSlamGlobalStateInTime const & state_in_time) {
-        auto const & state = state_in_time.state;
-
-        if (state_in_time.has_ros_timestamp == 0) {
-            RCLCPP_ERROR(get_logger(), "LPSLAM result does not contain ROS timestamp, can't use tracking result");
-            return;
-        }
-
-        auto const imageTimestamp = lpSlamRosTime(state_in_time.ros_timestamp);
-
-        tf2::Stamped<tf2::Transform> odom_to_map;
-        tf2::Quaternion q(state.orientation.z, -state.orientation.y, state.orientation.x,
-                            state.orientation.w);
-        tf2::Vector3 p(state.position.z,-state.position.y, state.position.x);
-        tf2::Vector3 p_rot = tf2::quatRotate(q, p);
-        tf2::Stamped<tf2::Transform> cam_to_map(
-            tf2::Transform(q, -p_rot), tf2_ros::fromMsg(imageTimestamp), m_camera_frame_id);
-
-        try {
-            geometry_msgs::msg::TransformStamped cam_to_map_msg, base_to_map_msg, odom_to_map_msg;
-
-            // https://github.com/ros2/geometry2/issues/176
-            // not working for some reason...
-            // base_to_map_msg = tf2::toMsg(base_to_map);
-            cam_to_map_msg.header.stamp = imageTimestamp;
-            cam_to_map_msg.header.frame_id = cam_to_map.frame_id_;
-            cam_to_map_msg.transform.translation.x = cam_to_map.getOrigin().getX();
-            cam_to_map_msg.transform.translation.y = cam_to_map.getOrigin().getY();
-            cam_to_map_msg.transform.translation.z = cam_to_map.getOrigin().getZ();
-            cam_to_map_msg.transform.rotation = tf2::toMsg(cam_to_map.getRotation());
-
-            m_tfBuffer->transform(cam_to_map_msg, base_to_map_msg, m_base_frame_id);
-
-            odom_to_map_msg = m_tfBuffer->transform(base_to_map_msg, m_odom_frame_id);
-            tf2::fromMsg(odom_to_map_msg, odom_to_map);
-        } catch (tf2::TransformException & e) {
-            RCLCPP_ERROR(get_logger(), "Transform from base_link to odom failed: %s",
-            e.what());
-            return;
-        }
-
-        // set map to odom for our transformation thread to publish
-        tf2::Transform map_to_odom = tf2::Transform(tf2::Quaternion(odom_to_map.getRotation() ),
-            tf2::Vector3(odom_to_map.getOrigin() ) ).inverse();
-
-        geometry_msgs::msg::TransformStamped msg;
-        msg.transform = tf2::toMsg(map_to_odom);
-        msg.child_frame_id = m_odom_frame_id;
-        msg.header.frame_id = m_map_frame_id;
-        msg.header.stamp = imageTimestamp + m_transform_tolerance;
-
-
-        RCLCPP_DEBUG(get_logger(), "Sending out new transform %f %f %f rot %f %f %f %f",
-                   msg.transform.translation.x,
-                    msg.transform.translation.y,
-                    msg.transform.translation.z,
-                    msg.transform.rotation.w,
-                    msg.transform.rotation.x,
-                    msg.transform.rotation.y,
-                    msg.transform.rotation.z);
-
-        m_lastTransform = msg;
-
-        m_tfBroadcaster->sendTransform(msg);
-    }
-
-    LpSlamGlobalStateInTime transformToLpSlamGlobalState(geometry_msgs::msg::TransformStamped const& tf) {
-        LpSlamGlobalStateInTime ros_state;
-        // ignored by LpSlam at the moment
-        ros_state.timestamp = 0;
-        ros_state.state.position = {tf.transform.translation.z,
-            -tf.transform.translation.y,
-            tf.transform.translation.x,
-            0.1, 0.1, 0.1};
-
-        const auto qRot = tf2::Quaternion(tf.transform.rotation.x,
-            tf.transform.rotation.y,
-            tf.transform.rotation.z,
-            tf.transform.rotation.w);
-
-        // LpSlam Convention needs an inverted quaternion
-        const auto invRot = qRot.inverse();
-
-        ros_state.state.orientation = {invRot.w(),
-            invRot.z(),
-            -invRot.y(),
-            invRot.x(), 0.1};
-
-        ros_state.state.valid = true;
-
-        return ros_state;
-    }
-
-    rclcpp::Time lpSlamRosTime( LpSlamROSTimestamp const& ts ) const {
-        // note: need to use the constructor with just nanoseconds because
-        // it can use int64, the one taking seconds and nanosconds only takes
-        // int32 nanoseconds, therefore cutting off large entries of
-        // nano seconds
-        return rclcpp::Time(ts.nanoseconds + ts.seconds * std::pow(10,9));
-    }
-
-    LpSlamROSTimestamp rosTimeToLpSlam( rclcpp::Time const& ts ) const {
-        return LpSlamROSTimestamp{0, ts.nanoseconds()};
-    }
-
-    // publishers
-    std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointcloudPublisher;
-    std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>> m_occGridPublisher;
-    std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::MapMetaData>> m_mapMetaDataPublisher;
-    std::shared_ptr<rclcpp::Publisher<lpslam_interfaces::msg::LpSlamStatus>> m_slamStatusPublisher;
-
-    // subscribers
-    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr m_laserScanSubsription;
-    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr m_leftImageSubscription;
-    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr m_rightImageSubscription;
-    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr m_cameraInfoSubscription;
-
-    // TF2 handlers
-    std::shared_ptr<tf2_ros::TransformListener> m_tfListener;
-    std::shared_ptr<tf2_ros::Buffer> m_tfBuffer;
-    std::shared_ptr<tf2_ros::TransformBroadcaster> m_tfBroadcaster;
-    std::vector<LpSlamFeatureEntry> m_featurePointBuffer;
-
-    // Timers
-    std::shared_ptr<rclcpp::TimerBase> m_pointcloud_timer;
-    std::shared_ptr<rclcpp::TimerBase> m_occmap_timer;
-    std::shared_ptr<rclcpp::TimerBase> m_slamstatus_timer;
-
-    // buffering of incoming images to compile one stereo image
-    std::vector<uint8_t> m_rightImageBuffer;
-    std::optional<builtin_interfaces::msg::Time> m_rightImageTimestamp;
-    std::mutex m_rightImageMutex;
-
-    std::vector<uint8_t> m_leftImageBuffer;
-    std::optional<builtin_interfaces::msg::Time> m_leftImageTimestamp;
-    std::mutex m_leftImageMutex;
-
-    // frame ids
-    std::string m_map_frame_id;
-    std::string m_camera_frame_id;
-    std::string m_odom_frame_id;
-    std::string m_laserscan_frame_id;
-    std::string m_base_frame_id;
-
-    std::optional<geometry_msgs::msg::TransformStamped> m_lastTransform;
-
-    // configuration variables
-    std::string m_configFile;
-    std::string m_lpSlamLogFile;
-    bool m_use_odometry;
-    bool m_writeLpSlamLog;
-    bool m_isStereoCamera;
-    double m_cameraFps;
-    bool m_consumeLaser;
-    double m_timespanMatch;
-    // means that both stereo images are in one physical image
-    // transferred via the ROS topic left_image_raw
-    bool m_isCombinedStereoImage;
-    tf2::Duration m_transform_tolerance;
-
-    // the godly SlamManager
-    LpSlamManager m_slam;
-
-    std::string m_vSlamMethod;
-
-    // OpenVSLAM parameters
-    int m_openVSlam_maxNumKeypoints;
-    int m_openVSlam_iniMaxNumKeypoints;
-    double m_openVSlam_scaleFactor;
-    int m_openVSlam_numLevels;
-    int m_openVSlam_iniFastThreshold;
-    int m_openVSlam_minFastThreshold;
-    double m_openVSlam_depthThreshold;
-    double m_openVSlam_depthmapFactor;
-    double m_openVSlam_mappingBaselineDistThr;
-    double m_openVSlam_pangolinViewerFps;
-
-    std::string m_openVSlamYaml;
-    std::string m_lpSlamJson;
-    // whether the camera config was read
-    bool m_cameraConfigured;
-    // including camera color encoding
-    std::string m_cameraEncoding;
-    std::mutex m_cameraEncodingMutex;
-};
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "LpSlamNode.hpp"
 
 void outside_lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &state_in_time, void *lpslam_node)
 {
@@ -1073,7 +22,8 @@ void outside_lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &stat
 LpSlamRequestNavDataResult outside_lpslam_RequestNavDataCallback(LpSlamROSTimestamp for_ros_time,
     LpSlamGlobalStateInTime * odometry,
     LpSlamGlobalStateInTime * map,
-    void * lpslam_node){
+    void * lpslam_node)
+{
     return static_cast<LpSlamNode *>(lpslam_node)->lpslam_RequestNavDataCallback(for_ros_time,
         odometry, map);
 }
@@ -1081,17 +31,522 @@ LpSlamRequestNavDataResult outside_lpslam_RequestNavDataCallback(LpSlamROSTimest
 LpSlamRequestNavTransformation outside_lpslam_RequestNavTransformationCallback(LpSlamROSTimestamp ros_time,
     LpSlamNavDataFrame from_frame,
     LpSlamNavDataFrame to_frame,
-    void * lpslam_node) {
+    void * lpslam_node)
+{
     return static_cast<LpSlamNode *>(lpslam_node)->lpslam_RequestNavTransformationCallback(ros_time,
         from_frame, to_frame);
 }
 
-int main(int argc, char **argv)
+LpSlamNode::LpSlamNode() : LpBaseNode()
 {
-    rclcpp::init(argc, argv);
-    auto node = std::make_shared<LpSlamNode>();
-    rclcpp::spin(node);
-    rclcpp::shutdown();
+    RCLCPP_INFO(get_logger(), "starting LpSlam node");
 
-    return 0;
+    if (!setParameters()) {
+        return;
+    }
+
+    setSubscribers();
+    setPublishers();
+
+    if (m_cameraInfoTopic.empty()) {
+        // Camera calibration files won't be read from topic.
+        // Starting SLAM manually.
+        startSlam();
+    }
+
+    setTimers();
+}
+
+LpSlamNode::~LpSlamNode()
+{
+    RCLCPP_INFO(get_logger(), "shutting down LpSlam");
+    resetTimers();
+    stopSlam();
+    RCLCPP_INFO(get_logger(), "shutting down LpSlam complete");
+}
+
+bool LpSlamNode::setParameters()
+{
+    m_configFile = this->declare_parameter<std::string>("lpslam_config", "");
+    m_lpSlamLogFile = this->declare_parameter<std::string>("lpslam_log_file", "lpslam.log");
+    m_writeLpSlamLog = this->declare_parameter<bool>("write_lpslam_log", false);
+    m_timespanMatch = this->declare_parameter<double>("timespan_match", 0.010); // 10 ms mach distance
+
+    m_lpslamStatusTopic = this->declare_parameter<std::string>(
+        "lpslam_status_topic", "lpslam_status");
+
+    m_lpSlamJson = m_configFile;
+
+    return true;
+}
+
+void LpSlamNode::setSubscribers()
+{
+    // allow for relaxed QoS for laser scan in order to match
+    // the topic settings
+    auto laser_qos = rclcpp::QoS(rclcpp::SensorDataQoS());
+    if (m_qosReliability == "best_effort") {
+        laser_qos.best_effort();
+    } else {
+        // reliable
+        laser_qos.reliable();
+    }
+
+    if (m_consumeLaser) {
+        m_laserScanSubsription = this->create_subscription<sensor_msgs::msg::LaserScan>(
+            m_laserscanTopic, laser_qos,
+            std::bind(&LpSlamNode::laserscan_callback, this, std::placeholders::_1));
+    }
+
+    // allow for relaxed QoS for image in order to match
+    // the topic settings
+    auto video_qos = rclcpp::QoS(rclcpp::SensorDataQoS());
+    video_qos.keep_last(10);
+    if (m_qosReliability == "best_effort") {
+        video_qos.best_effort();
+    } else {
+        // reliable
+        video_qos.reliable();
+    }
+
+    m_leftImageSubscription = this->create_subscription<sensor_msgs::msg::Image>(
+        m_leftImageTopic, video_qos,
+        std::bind(&LpSlamNode::image_callback_left, this, std::placeholders::_1));
+    if (m_isStereoCamera && !m_isCombinedStereoImage)
+    {
+        m_rightImageSubscription = this->create_subscription<sensor_msgs::msg::Image>(
+            m_rightImageTopic, video_qos,
+            std::bind(&LpSlamNode::image_callback_right, this, std::placeholders::_1));
+    }
+
+    if (!m_cameraInfoTopic.empty())
+    {
+        m_cameraInfoSubscription = this->create_subscription<sensor_msgs::msg::CameraInfo>(
+            m_cameraInfoTopic, video_qos,
+            std::bind(&LpSlamNode::camera_info_callback, this, std::placeholders::_1));
+    }
+}
+
+void LpSlamNode::setPublishers()
+{
+    m_pointcloudPublisher = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+        m_pointcloudTopic, 1);
+
+    m_occGridPublisher = this->create_publisher<nav_msgs::msg::OccupancyGrid>(m_mapName,
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+    m_mapMetaDataPublisher = this->create_publisher<nav_msgs::msg::MapMetaData>(m_mapName + "_metadata",
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+    m_slamStatusPublisher = this->create_publisher<lpslam_interfaces::msg::LpSlamStatus>(
+        m_lpslamStatusTopic,
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+
+    m_tfBroadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+}
+
+void LpSlamNode::setTimers()
+{
+    // start publishing point cloud
+    auto ros_clock = rclcpp::Clock::make_shared();
+    m_pointcloud_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(m_pointcloudRate, 0),
+                                              [this]() {
+                                                  this->publishPointCloud();
+                                              });
+    m_occmap_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(m_mapRate, 0),
+                                              [this]() {
+                                                  this->publishOccMap();
+                                              });
+    m_slamstatus_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(1, 0),
+                                              [this]() {
+                                                  if (!isSlamStarted()) {
+                                                      return;
+                                                  }
+
+                                                  const auto state = this->m_slam.getSlamStatus();
+
+                                                  lpslam_interfaces::msg::LpSlamStatus ros_state;
+
+                                                    ros_state.localization_status = 0;
+                                                    if (state.localization == LpSlamLocalization_Off) {
+                                                        ros_state.localization_status = 0;
+                                                    } else if (state.localization == LpSlamLocalization_Initializing) {
+                                                        ros_state.localization_status = 1;
+                                                    } else if (state.localization == LpSlamLocalization_Tracking) {
+                                                        ros_state.localization_status = 2;
+                                                    } else if (state.localization == LpSlamLocalization_Lost) {
+                                                        ros_state.localization_status = 3;
+                                                    }
+
+                                                  ros_state.feature_points = state.feature_points;
+                                                  ros_state.key_frames = state.key_frames;
+                                                  ros_state.frame_time = state.frame_time;
+                                                  ros_state.fps = state.fps;
+
+                                                  this->m_slamStatusPublisher->publish(std::move(ros_state));
+                                              });
+}
+
+void LpSlamNode::resetTimers()
+{
+    m_pointcloud_timer.reset();
+    m_occmap_timer.reset();
+    m_slamstatus_timer.reset();
+}
+
+void LpSlamNode::startSlam()
+{
+    if (m_writeLpSlamLog)
+    {
+        m_slam.logToFile(m_lpSlamLogFile.c_str());
+    }
+    m_slam.setLogLevel(LpSlamLogLevel_Debug);
+    RCLCPP_INFO_STREAM(get_logger(), "Loading LpSlam configuration from " << m_lpSlamJson);
+    m_slam.readConfigurationFile(m_lpSlamJson.c_str());
+
+    m_slam.addOnReconstructionCallback(&outside_lpslam_OnReconstructionCallback, this);
+    m_slam.addRequestNavTransformation(&outside_lpslam_RequestNavTransformationCallback, this);
+    if (m_useOdometry) {
+        m_slam.addRequestNavDataCallback(&outside_lpslam_RequestNavDataCallback, this);
+    }
+
+    m_slam.start();
+
+    setSlamStarted(true);
+    RCLCPP_INFO(get_logger(), "LpSlam processing starting");
+}
+
+// according to https://github.com/ros2/common_interfaces/blob/master/nav_msgs/msg/OccupancyGrid.msg
+// http://docs.ros.org/en/api/nav_msgs/html/msg/MapMetaData.html
+void LpSlamNode::publishOccMap()
+{
+    if (!isSlamStarted()) {
+        return;
+    }
+
+    if (m_occGridPublisher->get_subscription_count() == 0) {
+        return;
+    }
+
+    RCLCPP_DEBUG(get_logger(), "Start publishing occupancy map");
+    const auto rawSizeNeeded = m_slam.mappingGetMapRawSize();
+
+    nav_msgs::msg::OccupancyGrid occGridMessage;
+    occGridMessage.data.resize(rawSizeNeeded);
+
+    const auto mapInfo = m_slam.mappingGetMapRaw(occGridMessage.data.data(), occGridMessage.data.size());
+    const auto exportCount = mapInfo.y_cell_count * mapInfo.x_cell_count;
+    RCLCPP_DEBUG(get_logger(), "exported %u occupancy map points", exportCount);
+
+    occGridMessage.info.height = mapInfo.y_cell_count;
+    occGridMessage.info.width = mapInfo.x_cell_count;
+    occGridMessage.info.resolution = mapInfo.x_cell_size;
+    occGridMessage.info.origin.position.x = mapInfo.x_origin;
+    occGridMessage.info.origin.position.y = mapInfo.y_origin;
+
+    RCLCPP_DEBUG(get_logger(), "occupancy map origin (%f, %f)", occGridMessage.info.origin.position.x,
+        occGridMessage.info.origin.position.y);
+
+    //  account for higher placement of camera
+    occGridMessage.info.origin.position.z = -1.15;
+
+    occGridMessage.header.frame_id = m_map_frame_id;
+    occGridMessage.header.stamp = this->now();
+
+    m_occGridPublisher->publish(std::move(occGridMessage));
+    m_mapMetaDataPublisher->publish(std::move(occGridMessage.info));
+    RCLCPP_DEBUG(get_logger(), "Finished publishing occupancy map");
+}
+
+void LpSlamNode::publishPointCloud()
+{
+    if (!isSlamStarted()) {
+        return;
+    }
+
+    if (m_pointcloudPublisher->get_subscription_count() == 0) {
+        return;
+    }
+
+    RCLCPP_DEBUG(get_logger(), "Starting to publish feature points");
+
+    // can do that because the LpSlam structure has exactly three floats
+    // might change in the future
+    if (sizeof(LpSlamFeatureEntry) != (sizeof(float) * 3))
+    {
+        RCLCPP_ERROR(get_logger(), "Assumption about LpSlamFeatureEntry struct size not correct");
+        return;
+    }
+
+    // ignored by the API anyways
+    LpSlamMapBoundary bounds;
+    std::vector<LpSlamFeatureEntry> featurePointBuffer;
+    auto featureSize = m_slam.mappingGetFeaturesCount(bounds);
+
+    // limit the max points for now
+    featureSize = std::min(featureSize, std::size_t(50000));
+    featurePointBuffer.resize(featureSize);
+
+    // transform from LpSlam coords to ROS
+    //transformation lpslam -> ROS is
+    // z_ros = x_lpslam
+    // x_ros = z_lpslam
+    // y_ros = -y_lpslam
+
+    LpSlamMatrix9x9 lpslam_to_ros = {
+        0.0,  0.0,  1.0,
+        0.0, -1.0,  0.0,
+        1.0,  0.0,  0.0
+    };
+
+    auto outputSize = m_slam.mappingGetFeatures(bounds, featurePointBuffer.data(),
+                                               featureSize, lpslam_to_ros);
+
+    RCLCPP_DEBUG_STREAM(get_logger(), "Streaming out " << outputSize << " feature points");
+    featurePointBuffer.resize(outputSize);
+
+    // from https://github.com/ros/common_msgs/blob/jade-devel/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
+
+    // Create a PointCloud2
+    auto cloud_msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    // Fill some internals of the PoinCloud2 like the header/width/height ...
+    cloud_msg->header.frame_id = m_map_frame_id;
+    cloud_msg->header.stamp = this->now();
+
+    cloud_msg->height = 1;
+    cloud_msg->width = 3;
+    // Set the point fields to xyzrgb and resize the vector with the following command
+    // 4 is for the number of added fields. Each come in triplet: the name of the PointField,
+    // the number of occurrences of the type in the PointField, the type of the PointField
+    sensor_msgs::PointCloud2Modifier modifier(*cloud_msg.get());
+    modifier.setPointCloud2Fields(3, "x", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                  "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                  "z", 1, sensor_msgs::msg::PointField::FLOAT32);
+    // For convenience and the xyz, rgb, rgba fields, you can also use the following overloaded function.
+    // You have to be aware that the following function does add extra padding for backward compatibility though
+    // so it is definitely the solution of choice for PointXYZ and PointXYZRGB
+    // 2 is for the number of fields to add
+    //modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
+    // You can then reserve / resize as usual
+    modifier.resize(outputSize);
+
+    cloud_msg->is_bigendian = false;
+    cloud_msg->is_dense = false;
+
+    float* cloud_msg_ptr = (float*)(&cloud_msg->data[0]);
+    std::memcpy(cloud_msg_ptr, (float*)featurePointBuffer.data(), outputSize * sizeof(LpSlamFeatureEntry));
+
+    m_pointcloudPublisher->publish(std::move(cloud_msg));
+    RCLCPP_DEBUG(get_logger(), "Finished publishing feature points");
+}
+
+bool LpSlamNode::check_and_dispatch(
+    const sensor_msgs::msg::Image::SharedPtr this_msg,
+    std::vector<uint8_t> &otherImageBuffer,
+    std::optional<builtin_interfaces::msg::Time> &otherTimestamp,
+    std::mutex &otherMutex,
+    bool isLeft)
+{
+    std::scoped_lock lock(otherMutex);
+
+    // is the cached image close in time what we already got ?
+    if (!otherTimestamp.has_value())
+    {
+        return false;
+    }
+
+    uint64_t diff_seconds = otherTimestamp->sec - this_msg->header.stamp.sec;
+    uint64_t diff_nanoseconds = otherTimestamp->nanosec - this_msg->header.stamp.nanosec;
+
+    double dt = diff_seconds + std::pow(10, -9) * double(diff_nanoseconds);
+
+    if (std::abs(dt) > m_timespanMatch)
+    {
+        return false;
+    }
+
+    // dispatch both images
+    LpSlamImageDescription imgDesc;
+    imgDesc.structure = LpSlamImageStructure_Stereo_TwoBuffer;
+    if (this_msg->encoding == "mono8" ) {
+        imgDesc.format = LpSlamImageFormat_8UC1;
+    } else {
+        imgDesc.format = LpSlamImageFormat_8UC3;
+    }
+    imgDesc.image_conversion = LpSlamImageConversion_None;
+    imgDesc.height = this_msg->height;
+    imgDesc.width = this_msg->width;
+    imgDesc.imageSize = this_msg->step * this_msg->height;
+    imgDesc.hasRosTimestamp = 1;
+    imgDesc.rosTimestamp.seconds = this_msg->header.stamp.sec;
+    imgDesc.rosTimestamp.nanoseconds = this_msg->header.stamp.nanosec;
+
+    // slam timestamp
+    uint64_t slam_ts = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+
+    // forward to library
+    m_slam.addStereoImageFromBuffer(0,
+                                    // timestamp
+                                    slam_ts,
+                                    isLeft ? this_msg->data.data() : otherImageBuffer.data(),
+                                    isLeft ? otherImageBuffer.data() : this_msg->data.data(),
+                                    imgDesc);
+    otherTimestamp.reset();
+    return true;
+}
+
+// Callbacks
+void LpSlamNode::image_callback_right(const sensor_msgs::msg::Image::SharedPtr msg)
+{
+    if (check_and_dispatch(msg, m_leftImageBuffer, m_leftImageTimestamp, m_leftImageMutex, false))
+    {
+        return;
+    }
+
+    {
+        std::scoped_lock lock(m_rightImageMutex);
+        m_rightImageBuffer.resize(msg->step * msg->height);
+        std::memcpy(m_rightImageBuffer.data(), msg->data.data(),
+                    m_rightImageBuffer.size());
+        m_rightImageTimestamp = msg->header.stamp;
+    }
+}
+
+void LpSlamNode::image_callback_left(const sensor_msgs::msg::Image::SharedPtr msg)
+{
+    const std::string camera_encoding = getCameraEncoding();
+    if (camera_encoding.empty()) {
+        setCameraEncoding(msg->encoding);
+    }
+
+    if (check_and_dispatch(msg, m_rightImageBuffer, m_rightImageTimestamp, m_rightImageMutex, true))
+    {
+        return;
+    }
+    {
+        std::scoped_lock lock(m_leftImageMutex);
+        m_leftImageBuffer.resize(msg->step * msg->height);
+        std::memcpy(m_leftImageBuffer.data(), msg->data.data(),
+                    m_leftImageBuffer.size());
+        m_leftImageTimestamp = msg->header.stamp;
+    }
+}
+
+void LpSlamNode::laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+{
+    // This can be used to transform laser scan into camera frame
+    // http://docs.ros.org/en/latest/api/tf2_ros/html/c++/classtf2__ros_1_1BufferInterface.html#a12d0bda7d7533f199e94dae4bb46ba7a
+    // Use this method to lookup the transform of the laser data at time t_l to the camera pose at t_c
+
+    RCLCPP_DEBUG(get_logger(), "Received %lu laser scans with min %f max %f angle start %f angle end %f",
+        msg->ranges.size(), msg->range_min, msg->range_max, msg->angle_min, msg->angle_max);
+
+    // wait up to 100 ms for transform to arrive, parameter is nanoseconds
+    auto transformTimeout = rclcpp::Duration::from_nanoseconds(0.1 * std::pow(10.0, 9.0));
+
+    std::optional<geometry_msgs::msg::TransformStamped> odomTransform;
+    try {
+        // first: target frame
+        // second: source frame
+        // get the transformation for the laser scan's time, get odometry frame
+        // because this information is not really used by LPSLAM and its always available,
+        // in contrast to map frame transform
+        odomTransform = m_tfBuffer->lookupTransform(m_odom_frame_id, m_laserscan_frame_id,
+            msg->header.stamp, transformTimeout);
+    } catch (tf2::LookupException &ex) {
+        RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
+        return;
+    } catch (tf2::ConnectivityException &ex) {
+        RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
+        return;
+    } catch (tf2::ExtrapolationException &ex) {
+        RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
+        return;
+    } catch (tf2::InvalidArgumentException &ex) {
+        RCLCPP_ERROR(get_logger(), "Cannot process laser scan because map -> laser transformation not available: %s", ex.what());
+        return;
+    }
+
+    auto lpstate = transformToLpSlamGlobalState(odomTransform.value());
+    lpstate.has_ros_timestamp = true;
+    lpstate.ros_timestamp = rosTimeToLpSlam(msg->header.stamp);
+
+    // use the odomtry transform to get the global coordinates because its more reliable and faster
+    // than the pure optical measurement
+    // LaserScan data is obviously in laser frame
+    m_slam.mappingAddLaserScan(lpstate, msg->ranges.data(), msg->ranges.size(),
+        msg->range_min, msg->range_max,
+        msg->angle_min, msg->angle_max,
+        msg->angle_increment, 3.0);
+
+    RCLCPP_DEBUG(get_logger(), "Laser data dispatched");
+}
+
+void LpSlamNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg)
+{
+    if (m_cameraConfigured)
+    {
+        return;
+    }
+
+    // Make OpenVSLAM config-file
+    if (!make_openvslam_config(msg))
+    {
+        return;
+    }
+    // Update LP-SLAM config file with prepared OpenVSLAM one
+    if (!make_lpslam_config())
+    {
+        return;
+    }
+
+    // All configurations were prepared. Starting SLAM.
+    startSlam();
+
+    // Once camera was configured, no more actions needed here
+    m_cameraConfigured = true;
+}
+
+bool LpSlamNode::make_lpslam_config()
+{
+    if (m_openVSlamYaml.empty())
+    {
+        RCLCPP_ERROR(get_logger(), "No OpenVSLAM config-file prepared");
+        return false;
+    }
+
+    // Write formed YAML to file
+    m_lpSlamJson = std::tmpnam(nullptr);
+    m_lpSlamJson += ".json";
+    try {
+        // Open m_configFile for reading
+        std::ifstream in_json(m_configFile);
+        std::string ln;
+        // And m_lpSlamJson for writing
+        std::ofstream out_json(m_lpSlamJson);
+        size_t config_pos;
+        // Replace "configFromFile" field with m_openVSlamYaml
+        while (std::getline(in_json, ln))
+        {
+            config_pos = ln.find("configFromFile");
+            if (config_pos != std::string::npos)
+            {
+                ln = ln.substr(0, config_pos) +
+                    "configFromFile\": \"" + m_openVSlamYaml + "\",";
+            }
+            out_json << ln << std::endl;
+        }
+        in_json.close();
+        out_json.close();
+    } catch (std::exception & e) {
+        RCLCPP_ERROR(
+            get_logger(), "Error while processing %s -> to %s: %s",
+            m_configFile.c_str(), m_lpSlamJson.c_str(), e.what());
+        return false;
+    }
+    RCLCPP_INFO(get_logger(), "%s LP-SLAM config has been prepared", m_lpSlamJson.c_str());
+    return true;
+}
+
+void LpSlamNode::stopSlam()
+{
+    m_slam.stop();
 }

--- a/src/LpSlamNode.hpp
+++ b/src/LpSlamNode.hpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2021 LP-Research Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LP_SLAM_NODE_HPP_
+#define LP_SLAM_NODE_HPP_
+
+#include "LpBaseNode.hpp"
+
+#include <lpslam_interfaces/msg/lp_slam_status.hpp>
+#include "LpSlamManager.h"
+
+void outside_lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &state_in_time, void *lpslam_node);
+
+LpSlamRequestNavDataResult outside_lpslam_RequestNavDataCallback(LpSlamROSTimestamp for_ros_time,
+    LpSlamGlobalStateInTime * odometry,
+    LpSlamGlobalStateInTime * map,
+    void * lpslam_node);
+
+LpSlamRequestNavTransformation outside_lpslam_RequestNavTransformationCallback(LpSlamROSTimestamp ros_time,
+    LpSlamNavDataFrame from_frame,
+    LpSlamNavDataFrame to_frame,
+    void * lpslam_node);
+
+class LpSlamNode : public LpBaseNode
+{
+public:
+    LpSlamNode();
+    ~LpSlamNode();
+
+private:
+    bool setParameters();
+    void setSubscribers();
+    void setPublishers();
+    void setTimers();
+    void resetTimers();
+
+    void startSlam();
+
+    void publishOccMap();
+    void publishPointCloud();
+
+    bool check_and_dispatch(const sensor_msgs::msg::Image::SharedPtr this_msg,
+                            std::vector<uint8_t> &otherImageBuffer,
+                            std::optional<builtin_interfaces::msg::Time> &otherTimestamp,
+                            std::mutex &otherMutex,
+                            bool isLeft);
+
+    // callbacks
+    void image_callback_right(const sensor_msgs::msg::Image::SharedPtr msg);
+    void image_callback_left(const sensor_msgs::msg::Image::SharedPtr msg);
+    void laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
+    void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
+
+    // Config makers
+    bool make_lpslam_config();
+
+public:
+    void stopSlam();
+
+private:
+    // publishers
+    std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointcloudPublisher;
+    std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>> m_occGridPublisher;
+    std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::MapMetaData>> m_mapMetaDataPublisher;
+    std::shared_ptr<rclcpp::Publisher<lpslam_interfaces::msg::LpSlamStatus>> m_slamStatusPublisher;
+
+    // subscribers
+    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr m_laserScanSubsription;
+    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr m_leftImageSubscription;
+    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr m_rightImageSubscription;
+    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr m_cameraInfoSubscription;
+
+    // Timers
+    std::shared_ptr<rclcpp::TimerBase> m_pointcloud_timer;
+    std::shared_ptr<rclcpp::TimerBase> m_occmap_timer;
+    std::shared_ptr<rclcpp::TimerBase> m_slamstatus_timer;
+
+    // buffering of incoming images to compile one stereo image
+    std::vector<uint8_t> m_rightImageBuffer;
+    std::optional<builtin_interfaces::msg::Time> m_rightImageTimestamp;
+    std::mutex m_rightImageMutex;
+
+    std::vector<uint8_t> m_leftImageBuffer;
+    std::optional<builtin_interfaces::msg::Time> m_leftImageTimestamp;
+    std::mutex m_leftImageMutex;
+
+    // configuration variables
+    std::string m_configFile;
+    std::string m_lpSlamLogFile;
+    bool m_writeLpSlamLog;
+    double m_timespanMatch;
+    std::string m_lpslamStatusTopic;
+
+    // the godly SlamManager
+    LpSlamManager m_slam;
+    // LpSlam input JSON file
+    std::string m_lpSlamJson;
+};
+
+#endif  // LP_SLAM_NODE_HPP_

--- a/src/OpenVSLAMNode.cpp
+++ b/src/OpenVSLAMNode.cpp
@@ -1,0 +1,623 @@
+// Copyright (C) 2021 LP-Research Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "OpenVSLAMNode.hpp"
+
+OpenVSLAMNode::OpenVSLAMNode() : LpBaseNode()
+{
+    RCLCPP_INFO(get_logger(), "starting OpenVSlam node");
+
+    if (!setParameters()) {
+        return;
+    }
+
+    setSubscribers();
+    setPublishers();
+
+    if (m_cameraInfoTopic.empty()) {
+        // Camera calibration files won't be read from topic.
+        // Starting SLAM manually.
+        startSlam();
+    }
+
+    setTimers();
+}
+
+OpenVSLAMNode::~OpenVSLAMNode()
+{
+    RCLCPP_INFO(get_logger(), "shutting down OpenVSlam");
+    resetTimers();
+    stopSlam();
+    RCLCPP_INFO(get_logger(), "shutting down OpenVSlam complete");
+}
+
+#ifdef USE_PANGOLIN_VIEWER
+void OpenVSLAMNode::viewerExecute()
+{
+    if (m_viewer) {
+        m_viewer->run();
+    }
+}
+#endif  // USE_PANGOLIN_VIEWER
+
+bool OpenVSLAMNode::setParameters()
+{
+    // configuration variables
+    m_slamMode = this->declare_parameter<std::string>("slam_mode", "slam");
+    m_mappingDuringLocalization = this->declare_parameter<bool>(
+        "mapping_during_localization", true);
+    m_maxLaserAge = this->declare_parameter<double>("max_laser_age", 0.5);
+    m_laserTS.sec = 0;
+    m_laserTS.nanosec = 0;
+
+    // OpenVSLAM parameters
+    m_openVSlam_vocabFile = this->declare_parameter<std::string>(m_vSlamMethod + "." + "vocab_file", "");
+    if (!m_openVSlam_vocabFile.size()) {
+        RCLCPP_ERROR(get_logger(), "%s vocab_file is not specified", m_vSlamMethod.c_str());
+        return false;
+    }
+    m_openVSlam_mapDatabaseFile =
+        this->declare_parameter<std::string>(m_vSlamMethod + "." + "map_database", "map.db");
+
+    return true;
+}
+
+void OpenVSLAMNode::setSubscribers()
+{
+    // allow for relaxed QoS for laser scan in order to match
+    // the topic settings
+    auto laser_qos = rclcpp::QoS(rclcpp::SensorDataQoS());
+    if (m_qosReliability == "best_effort") {
+        laser_qos.best_effort();
+    } else {
+        // reliable
+        laser_qos.reliable();
+    }
+
+    if (m_consumeLaser) {
+        m_laserScanSubsription = this->create_subscription<sensor_msgs::msg::LaserScan>(
+            m_laserscanTopic, laser_qos,
+            std::bind(&OpenVSLAMNode::laserscan_callback, this, std::placeholders::_1));
+    }
+
+    if (m_isStereoCamera && !m_isCombinedStereoImage)
+    {
+        // allow for relaxed QoS for image in order to match
+        // the topic settings
+        rmw_qos_profile_t video_qos = rmw_qos_profile_sensor_data;
+        video_qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+        video_qos.depth = 10;
+        if (m_qosReliability == "best_effort") {
+            video_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+        } else {
+            // reliable
+            video_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+        }
+
+        m_leftImageSubscription =
+            std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
+                this, m_leftImageTopic, video_qos);
+        m_rightImageSubscription =
+            std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
+                this, m_rightImageTopic, video_qos);
+        m_synchronizer = std::make_shared<
+            message_filters::TimeSynchronizer<sensor_msgs::msg::Image, sensor_msgs::msg::Image>>(
+                *m_leftImageSubscription, *m_rightImageSubscription, 10);
+        m_synchronizer->registerCallback(&OpenVSLAMNode::image_callback_stereo, this);
+    }
+
+    if (!m_cameraInfoTopic.empty())
+    {
+        // allow for relaxed QoS for image in order to match
+        // the topic settings
+        auto video_qos = rclcpp::QoS(rclcpp::SensorDataQoS());
+        video_qos.keep_last(10);
+        if (m_qosReliability == "best_effort") {
+            video_qos.best_effort();
+        } else {
+            // reliable
+            video_qos.reliable();
+        }
+
+        m_cameraInfoSubscription = this->create_subscription<sensor_msgs::msg::CameraInfo>(
+            m_cameraInfoTopic, video_qos,
+            std::bind(&OpenVSLAMNode::camera_info_callback, this, std::placeholders::_1));
+    }
+}
+
+void OpenVSLAMNode::setPublishers()
+{
+    m_pointcloudPublisher = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+        m_pointcloudTopic, 1);
+
+    m_occGridPublisher = this->create_publisher<nav_msgs::msg::OccupancyGrid>(m_mapName,
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+    m_mapMetaDataPublisher = this->create_publisher<nav_msgs::msg::MapMetaData>(m_mapName + "_metadata",
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+
+    m_tfBroadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+}
+
+void OpenVSLAMNode::setTimers()
+{
+    // start publishing point cloud
+    auto ros_clock = rclcpp::Clock::make_shared();
+    m_pointcloud_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(m_pointcloudRate, 0),
+                                              [this]() {
+                                                  this->publishPointCloud();
+                                              });
+    m_occmap_timer = rclcpp::create_timer(this, ros_clock, rclcpp::Duration(m_mapRate, 0),
+                                              [this]() {
+                                                  this->publishOccMap();
+                                              });
+}
+
+void OpenVSLAMNode::resetTimers()
+{
+    m_pointcloud_timer.reset();
+    m_occmap_timer.reset();
+}
+
+void OpenVSLAMNode::startSlam()
+{
+    if (m_openVSlamYaml.empty()) {
+        RCLCPP_ERROR(get_logger(), "OpenVSLAM config yaml is not being set or prepared");
+        return;
+    }
+
+    try {
+        m_openVSlamCfg = std::make_shared<openvslam::config>(m_openVSlamYaml);
+        m_openVSlamCfg->write_logfile_ = true;
+    } catch (const std::exception& ex) {
+        RCLCPP_ERROR(
+            get_logger(),
+            "Failed to load OpenVSLAM config file %s because %s",
+            m_openVSlamYaml.c_str(), ex.what());
+        return;
+    }
+    m_openVSlam = std::make_unique<openvslam::system>(m_openVSlamCfg, m_openVSlam_vocabFile);
+
+    if (m_slamMode == "slam") {
+        RCLCPP_INFO(get_logger(), "Starting SLAM in mapping mode");
+
+        // Start SLAM in mapping mode
+        m_openVSlam->startup(true);
+    } else {
+        RCLCPP_INFO(get_logger(), "Starting SLAM in localization mode");
+
+        // Start SLAM in localization mode
+        m_openVSlam->startup(false);
+
+        // Local OpenVSLAM map database from file
+        if (does_exist(m_openVSlam_mapDatabaseFile)) {
+            RCLCPP_INFO(
+                get_logger(),
+                "Loading OpenVSLAM map database from %s",
+                m_openVSlam_mapDatabaseFile.c_str());
+            m_openVSlam->load_map_database(m_openVSlam_mapDatabaseFile);
+        }
+
+        // Enable or disable further mapping while working in localization mode
+        if (m_mappingDuringLocalization) {
+            RCLCPP_INFO(get_logger(), "Mapping is enabled in localization mode");
+            m_openVSlam->enable_mapping_module();
+        } else {
+            RCLCPP_INFO(get_logger(), "Mapping is disabled in localization mode");
+            m_openVSlam->disable_mapping_module();
+        }
+    }
+
+#ifdef USE_PANGOLIN_VIEWER
+    m_viewer = std::make_unique<pangolin_viewer::viewer>(
+        openvslam::util::yaml_optional_ref(m_openVSlamCfg->yaml_node_, "PangolinViewer"),
+        m_openVSlam.get(), m_openVSlam->get_frame_publisher(), m_openVSlam->get_map_publisher());
+    m_viewerThread = std::make_shared<std::thread>(&OpenVSLAMNode::viewerExecute, this);
+#endif  // USE_PANGOLIN_VIEWER
+
+    setSlamStarted(true);
+    RCLCPP_INFO(get_logger(), "OpenVSLAM processing starting");
+}
+
+// according to https://github.com/ros2/common_interfaces/blob/master/nav_msgs/msg/OccupancyGrid.msg
+// http://docs.ros.org/en/api/nav_msgs/html/msg/MapMetaData.html
+void OpenVSLAMNode::publishOccMap()
+{
+    if (!isSlamStarted()) {
+        return;
+    }
+
+    if (m_occGridPublisher->get_subscription_count() == 0) {
+        return;
+    }
+
+    RCLCPP_DEBUG(get_logger(), "Start publishing occupancy map");
+    const unsigned long rawSizeNeeded =
+        m_openVSlam->get_map_publisher()->occupancy_map_export_size_required();
+
+    nav_msgs::msg::OccupancyGrid occGridMessage;
+    occGridMessage.data.resize(rawSizeNeeded);
+
+    const openvslam::data::occupancy_map_info mapInfo =
+        m_openVSlam->get_map_publisher()->occupancy_map_export(
+            occGridMessage.data.data(),
+            rawSizeNeeded);
+    const unsigned long exportCount = mapInfo.width * mapInfo.height;
+    RCLCPP_DEBUG(get_logger(), "exported %lu occupancy map points", exportCount);
+
+    occGridMessage.info.height = mapInfo.height;
+    occGridMessage.info.width = mapInfo.width;
+    occGridMessage.info.resolution = mapInfo.resolution;
+    occGridMessage.info.origin.position.x = mapInfo.origin_x;
+    occGridMessage.info.origin.position.y = mapInfo.origin_y;
+    occGridMessage.info.origin.position.z = 0.0;
+
+    RCLCPP_DEBUG(get_logger(), "occupancy map origin (%f, %f)", occGridMessage.info.origin.position.x,
+        occGridMessage.info.origin.position.y);
+
+    occGridMessage.header.frame_id = m_map_frame_id;
+    occGridMessage.header.stamp = this->now();
+
+    m_occGridPublisher->publish(std::move(occGridMessage));
+    m_mapMetaDataPublisher->publish(std::move(occGridMessage.info));
+    RCLCPP_DEBUG(get_logger(), "Finished publishing occupancy map");
+}
+
+void OpenVSLAMNode::publishPointCloud()
+{
+    if (!isSlamStarted()) {
+        return;
+    }
+
+    if (m_pointcloudPublisher->get_subscription_count() == 0) {
+        return;
+    }
+
+    RCLCPP_DEBUG(get_logger(), "Starting to publish feature points");
+
+    if (sizeof(FeaturePosition) != (sizeof(float) * 3))
+    {
+        RCLCPP_ERROR(get_logger(), "Assumption about FeaturePosition struct size not correct");
+        return;
+    }
+
+    std::vector<FeaturePosition> featurePointBuffer;
+    // limit the max points for now
+    const size_t maxTotalFeatureSize = std::size_t(50000);
+
+    // from mappingGetFeatures()
+    auto lmd = [&featurePointBuffer, maxTotalFeatureSize]
+        ( std::unordered_map<unsigned int, openvslam::data::landmark*> const& features ) -> void {
+            size_t bufferSize = 0;
+            // transform from LpSlam coords to ROS
+            //transformation lpslam -> ROS is
+            // z_ros = x_lpslam
+            // x_ros = z_lpslam
+            // y_ros = -y_lpslam
+            Eigen::Matrix3f lpslam_to_ros;
+            lpslam_to_ros << 0.0,  0.0,  1.0,
+                             0.0, -1.0,  0.0,
+                             1.0,  0.0,  0.0;
+
+            for ( auto const& ft: features) {
+                auto const worldPos = ft.second->get_pos_in_world();
+                Eigen::Vector3f p_lpslam;//(-worldPos.y(), worldPos.x(), worldPos.z());
+                p_lpslam << -worldPos.y(), worldPos.x(), worldPos.z();
+                const Eigen::Vector3f p_transformed = lpslam_to_ros * p_lpslam;
+
+                featurePointBuffer.push_back({p_transformed.x(), p_transformed.y(), p_transformed.z()});
+                bufferSize++;
+                if (bufferSize >= maxTotalFeatureSize) {
+                    break;
+                }
+            }
+        };
+
+    std::function<void(std::unordered_map<unsigned int, openvslam::data::landmark*> const&)> funcLamda
+         = lmd;
+
+    m_openVSlam->get_map_publisher()->execute_on_landmarks(funcLamda);
+
+    const size_t outputSize = featurePointBuffer.size();
+
+    RCLCPP_DEBUG_STREAM(get_logger(), "Streaming out " << outputSize << " feature points");
+
+    // from https://github.com/ros/common_msgs/blob/jade-devel/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
+
+    // Create a PointCloud2
+    auto cloud_msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    // Fill some internals of the PoinCloud2 like the header/width/height ...
+    cloud_msg->header.frame_id = m_map_frame_id;
+    cloud_msg->header.stamp = this->now();
+
+    cloud_msg->height = 1;
+    cloud_msg->width = 3;
+    // Set the point fields to xyzrgb and resize the vector with the following command
+    // 4 is for the number of added fields. Each come in triplet: the name of the PointField,
+    // the number of occurrences of the type in the PointField, the type of the PointField
+    sensor_msgs::PointCloud2Modifier modifier(*cloud_msg.get());
+    modifier.setPointCloud2Fields(3, "x", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                  "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                  "z", 1, sensor_msgs::msg::PointField::FLOAT32);
+    // For convenience and the xyz, rgb, rgba fields, you can also use the following overloaded function.
+    // You have to be aware that the following function does add extra padding for backward compatibility though
+    // so it is definitely the solution of choice for PointXYZ and PointXYZRGB
+    // 2 is for the number of fields to add
+    //modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
+    // You can then reserve / resize as usual
+    modifier.resize(outputSize);
+
+    cloud_msg->is_bigendian = false;
+    cloud_msg->is_dense = false;
+
+    float* cloud_msg_ptr = (float*)(&cloud_msg->data[0]);
+    std::memcpy(cloud_msg_ptr, (float*)featurePointBuffer.data(), outputSize * sizeof(FeaturePosition));
+
+    m_pointcloudPublisher->publish(std::move(cloud_msg));
+    RCLCPP_DEBUG(get_logger(), "Finished publishing feature points");
+}
+
+// Callbacks
+void OpenVSLAMNode::image_callback_stereo(
+    const sensor_msgs::msg::Image::SharedPtr left,
+    const sensor_msgs::msg::Image::SharedPtr right)
+{
+    const std::string camera_encoding = getCameraEncoding();
+    if (camera_encoding.empty()) {
+        setCameraEncoding(left->encoding);
+        // OpenVSLAM is not configured yet. No need to continue.
+        return;
+    }
+
+    if (!m_useOdometry) {
+        // Don't continue if there is no odometry data
+        RCLCPP_WARN(get_logger(), "Odometry data was disabled, skipping frame");
+        return;
+    }
+
+    auto leftcv = cv_bridge::toCvShare(left)->image;
+    auto rightcv = cv_bridge::toCvShare(right)->image;
+    if (leftcv.empty() || rightcv.empty()) {
+        return;
+    }
+
+    const double img_timestamp = left->header.stamp.sec + left->header.stamp.nanosec / 1e9;
+
+    // Get last camera pose in odom and map frame (if any)
+    LpSlamGlobalStateInTime last_odom_pose, last_map_pose;
+    LpSlamRequestNavDataResult res = lpslam_RequestNavDataCallback(
+        rosTimeToLpSlam(left->header.stamp),
+        &last_odom_pose, &last_map_pose);
+
+    // Convert camera pose in odom and map frames
+    // from LpSlamGlobalStateInTime -> to openvslam::navigation_state
+    openvslam::navigation_state cam_pose_odom, cam_pose_map;
+    cam_pose_odom.velocity_valid = false;  // Currently not utilized by LP-OpenVSLAM
+    cam_pose_map.velocity_valid = false;  // Currently not utilized by LP-OpenVSLAM
+    if (res == LpSlamRequestNavDataResult_OdomAndMap ||
+        res == LpSlamRequestNavDataResult_OdomOnly) {
+        // Last camera state in odom frame is valid
+        cam_pose_odom.valid = true;
+        cam_pose_odom.cam_translation = openvslam::Vec3_t(
+            last_odom_pose.state.position.y,
+            -last_odom_pose.state.position.x,
+            last_odom_pose.state.position.z);
+        const Eigen::Quaternion<double> cam_rot_q = Eigen::Quaternion<double>(
+            last_odom_pose.state.orientation.w,
+            last_odom_pose.state.orientation.y,
+            -last_odom_pose.state.orientation.x,
+            last_odom_pose.state.orientation.z);
+        cam_pose_odom.cam_rotation = cam_rot_q.normalized().toRotationMatrix();
+    } else {
+        // Last camera state in odom frame is invalid:
+        // don't continue if there is no odometry data
+        RCLCPP_ERROR(
+            get_logger(),
+            "Skipping camera frame for tracking because no odometry information available");
+        return;
+    }
+
+    if (res == LpSlamRequestNavDataResult_OdomAndMap ||
+        res == LpSlamRequestNavDataResult_MapOnly) {
+        // Last camera state in map frame is valid
+        cam_pose_map.valid = true;
+        cam_pose_map.cam_translation = openvslam::Vec3_t(
+            last_odom_pose.state.position.y,
+            -last_odom_pose.state.position.x,
+            last_odom_pose.state.position.z);
+        const Eigen::Quaternion<double> cam_rot_q = Eigen::Quaternion<double>(
+            last_odom_pose.state.orientation.w,
+            last_odom_pose.state.orientation.y,
+            -last_odom_pose.state.orientation.x,
+            last_odom_pose.state.orientation.z);
+        cam_pose_map.cam_rotation = cam_rot_q.normalized().toRotationMatrix();
+    } else {
+        // Last camera state in map frame is invalid
+        cam_pose_map.valid = false;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_laser2DMutex);
+
+        // Check whether laser scanner data is not outdated
+        if (m_laser2D.is_valid()) {
+            const int64_t dt_sec = static_cast<int64_t>(m_laserTS.sec) -
+                static_cast<int64_t>(left->header.stamp.sec);
+            const int64_t dt_nanosec = static_cast<int64_t>(m_laserTS.nanosec) -
+                static_cast<int64_t>(left->header.stamp.nanosec);
+            const double dt = dt_sec + dt_nanosec / 1e9;
+
+            if (std::abs(dt) < m_maxLaserAge) {
+                RCLCPP_INFO(get_logger(), "Selected laser data with dt %f to use", dt);
+            } else {
+                RCLCPP_ERROR(get_logger(), "Laser data with age %f is to old too use", dt);
+                m_laser2D.ranges_.clear();
+            }
+        }
+
+        // Track image
+        Eigen::Matrix4d cam_pose_cw = m_openVSlam->feed_stereo_frame(
+            leftcv, rightcv, img_timestamp, cv::Mat{},
+            cam_pose_odom, cam_pose_map, m_laser2D);
+
+        // Get tracking state
+        const openvslam::publish::frame_state frame_state = m_openVSlam->get_frame_state();
+        if (frame_state.tracker_state !=
+            openvslam::tracker_state_t::Tracking)
+        {
+            std::string state_string;
+            switch (frame_state.tracker_state) {
+                case openvslam::tracker_state_t::NotInitialized:
+                    state_string = "Not Initialized";
+                    break;
+                case openvslam::tracker_state_t::Initializing:
+                    state_string = "Initializing";
+                    break;
+                case openvslam::tracker_state_t::Lost:
+                    state_string = "Track Lost";
+                    break;
+                default:
+                    state_string = "Unknown State";
+                    break;
+            }
+            RCLCPP_WARN(
+                get_logger(),
+                "OpenVSLAM tracker is in \"%s\" state. Pose is not being published.",
+                state_string.c_str());
+            return;
+        }
+
+        LpSlamGlobalStateInTime res;
+        // Fill the state
+        //cam_center = -rot_cw.transpose() * trans_cw;
+        Eigen::Matrix3d rot_cw = cam_pose_cw.block<3, 3>(0, 0);
+        Eigen::Quaterniond q_rot_cw(rot_cw);
+        Eigen::Vector3d trans_cw = cam_pose_cw.block<3, 1>(0, 3);
+        Eigen::Vector3d cam_center = -rot_cw.transpose() * trans_cw;
+        // Convert pose from optical to LP coordinate system
+        res.state.position.x = -cam_center.y();
+        res.state.position.y = cam_center.x();
+        res.state.position.z = cam_center.z();
+        res.state.orientation.w = q_rot_cw.w();
+        res.state.orientation.x = -q_rot_cw.y();
+        res.state.orientation.y = q_rot_cw.x();
+        res.state.orientation.z = q_rot_cw.z();
+        res.state.valid = true;
+
+        // Fill the time
+        res.ros_timestamp.seconds = left->header.stamp.sec;
+        res.ros_timestamp.nanoseconds = left->header.stamp.nanosec;
+        res.has_ros_timestamp = true;
+
+        // Publish map->odom transform
+        lpslam_OnReconstructionCallback(res);
+    }
+}
+
+void OpenVSLAMNode::laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+{
+    // This can be used to transform laser scan into camera frame
+    // http://docs.ros.org/en/latest/api/tf2_ros/html/c++/classtf2__ros_1_1BufferInterface.html#a12d0bda7d7533f199e94dae4bb46ba7a
+    // Use this method to lookup the transform of the laser data at time t_l to the camera pose at t_c
+
+    RCLCPP_DEBUG(get_logger(), "Received %lu laser scans with min %f max %f angle start %f angle end %f",
+        msg->ranges.size(), msg->range_min, msg->range_max, msg->angle_min, msg->angle_max);
+
+    {
+        std::lock_guard<std::mutex> lock(m_laser2DMutex);
+
+        // Copying LaserScan data to laser2d
+        const size_t ranges_num = msg->ranges.size();
+        m_laser2D.ranges_.resize(ranges_num);
+        std::memcpy(m_laser2D.ranges_.data(), msg->ranges.data(), sizeof(float) * ranges_num);
+
+        // Setting other laser2d parameters
+        m_laser2D.angle_min_ = msg->angle_min;
+        m_laser2D.angle_max_ = msg->angle_max;
+        m_laser2D.angle_increment_ = msg->angle_increment;
+        m_laser2D.range_min_ = msg->range_min;
+        m_laser2D.range_max_ = msg->range_max;
+
+        // Obtaining m_laser2D.trans_lc_ and m_laser2D.rot_lc_
+        if (m_laser2D.is_valid()) {
+            // lookup transformation for laser data to camera!
+            const LpSlamGlobalState lp_laser_to_camera =
+                lpslam_RequestNavTransformationCallback(
+                    rosTimeToLpSlam(msg->header.stamp),
+                    LpSlamNavDataFrame_Laser, LpSlamNavDataFrame_Camera);
+
+            // Get relative movement between camera and laser at that time !
+            if (lp_laser_to_camera.valid) {
+                // Transform from laser -> to camera frame (or laser origin in camera's frame)
+                // Converting from LP to optical coordinate system.
+                m_laser2D.trans_lc_ = openvslam::Vec3_t(
+                    lp_laser_to_camera.position.y,
+                    -lp_laser_to_camera.position.x,
+                    lp_laser_to_camera.position.z);
+                const Eigen::Quaternion<double> vslam_r_lc = Eigen::Quaternion<double>(
+                    lp_laser_to_camera.orientation.w,
+                    lp_laser_to_camera.orientation.y,
+                    -lp_laser_to_camera.orientation.x,
+                    lp_laser_to_camera.orientation.z);
+                m_laser2D.rot_lc_ = vslam_r_lc.normalized().toRotationMatrix();
+            }
+        }
+
+        m_laserTS = msg->header.stamp;
+    }
+    RCLCPP_DEBUG(get_logger(), "Laser data dispatched");
+}
+
+void OpenVSLAMNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg)
+{
+    if (m_cameraConfigured)
+    {
+        return;
+    }
+
+    // Make OpenVSLAM config-file
+    if (!make_openvslam_config(msg))
+    {
+        return;
+    }
+
+    // All configurations were prepared. Starting SLAM.
+    startSlam();
+
+    // Once camera was configured, no more actions needed here
+    m_cameraConfigured = true;
+}
+
+void OpenVSLAMNode::stopSlam()
+{
+    // only save if we used the map and and mapping was enabled
+    if (m_slamMode == "slam") {
+        if (m_openVSlam_mapDatabaseFile.size()) {
+            RCLCPP_INFO(
+                get_logger(),
+                "Saving mapping database to %s", m_openVSlam_mapDatabaseFile.c_str());
+            m_openVSlam->save_map_database(m_openVSlam_mapDatabaseFile);
+        } else {
+            RCLCPP_WARN(get_logger(), "Won't save mapping because file name is invalid");
+        }
+    }
+
+#ifdef USE_PANGOLIN_VIEWER
+    m_viewerThread.reset();
+    m_viewer->request_terminate();
+    m_viewer.reset(nullptr);
+#endif  // USE_PANGOLIN_VIEWER
+
+    m_openVSlam->shutdown();
+    m_openVSlam.reset(nullptr);
+}

--- a/src/OpenVSLAMNode.hpp
+++ b/src/OpenVSLAMNode.hpp
@@ -1,0 +1,125 @@
+// Copyright (C) 2021 LP-Research Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENVSLAM_NODE_HPP_
+#define OPENVSLAM_NODE_HPP_
+
+#include "LpBaseNode.hpp"
+
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/time_synchronizer.h>
+#include <builtin_interfaces/msg/time.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <openvslam/system.h>
+#include <openvslam/data/laser2d.h>
+#include <openvslam/data/navigation_state.h>
+#include <openvslam/data/occupancy_map_info.h>
+#include <openvslam/data/landmark.h>
+#include <openvslam/tracker_state.h>
+#include <openvslam/publish/frame_state.h>
+#include <openvslam/publish/map_publisher.h>
+
+#ifdef USE_PANGOLIN_VIEWER
+#include <pangolin_viewer/viewer.h>
+#endif  // USE_PANGOLIN_VIEWER
+
+inline bool does_exist(std::string const& fname)
+{
+    std::ifstream infile(fname);
+    return infile.good();
+}
+
+struct FeaturePosition {
+  float x;
+  // +y right
+  float y;
+  // +z forward
+  float z;
+};
+
+class OpenVSLAMNode : public LpBaseNode
+{
+public:
+    OpenVSLAMNode();
+    ~OpenVSLAMNode();
+
+private:
+#ifdef USE_PANGOLIN_VIEWER
+    void viewerExecute();
+#endif  // USE_PANGOLIN_VIEWER
+
+    bool setParameters();
+    void setSubscribers();
+    void setPublishers();
+    void setTimers();
+    void resetTimers();
+
+    void startSlam();
+
+    void publishOccMap();
+    void publishPointCloud();
+
+    // callbacks
+    void image_callback_stereo(
+        const sensor_msgs::msg::Image::SharedPtr left,
+        const sensor_msgs::msg::Image::SharedPtr right);
+    void laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
+    void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
+
+public:
+    void stopSlam();
+
+private:
+    // publishers
+    std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointcloudPublisher;
+    std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>> m_occGridPublisher;
+    std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::MapMetaData>> m_mapMetaDataPublisher;
+
+    // subscribers
+    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr m_laserScanSubsription;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> m_leftImageSubscription;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> m_rightImageSubscription;
+    std::shared_ptr<message_filters::TimeSynchronizer<sensor_msgs::msg::Image, sensor_msgs::msg::Image>>
+            m_synchronizer;
+    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr m_cameraInfoSubscription;
+
+    // Timers
+    std::shared_ptr<rclcpp::TimerBase> m_pointcloud_timer;
+    std::shared_ptr<rclcpp::TimerBase> m_occmap_timer;
+
+    // Last laserscan data
+    openvslam::data::laser2d m_laser2D;
+    builtin_interfaces::msg::Time m_laserTS;
+    std::mutex m_laser2DMutex;
+
+    // configuration variables
+    std::string m_slamMode;
+    bool m_mappingDuringLocalization;
+    double m_maxLaserAge;
+
+    // OpenVSLAM parameters
+    std::string m_openVSlam_vocabFile;
+    std::string m_openVSlam_mapDatabaseFile;
+
+    // the godly SlamManager
+    std::unique_ptr<openvslam::system> m_openVSlam;
+    std::shared_ptr<openvslam::config> m_openVSlamCfg;
+#ifdef USE_PANGOLIN_VIEWER
+    std::unique_ptr<pangolin_viewer::viewer> m_viewer;
+    std::shared_ptr<std::thread> m_viewerThread;
+#endif  // USE_PANGOLIN_VIEWER
+};
+
+#endif  // OPENVSLAM_NODE_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2021 LP-Research Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef USE_OPENVSLAM_DIRECTLY
+#include "LpSlamNode.hpp"
+#define VSLAM LpSlamNode
+#else
+#include "OpenVSLAMNode.hpp"
+#define VSLAM OpenVSLAMNode
+#endif  // USE_OPENVSLAM_DIRECTLY
+
+// Signal handler for no-destructor issue:
+// https://answers.ros.org/question/364045/publish-message-on-destructor-works-only-on-rclpy
+// https://stackoverflow.com/questions/58644994/destructor-of-shared-ptr-object-never-called
+// https://github.com/ros2/rclcpp/issues/317
+std::shared_ptr<VSLAM> node_;
+void signal_handler(int /*sig_num*/)
+{
+    node_->stopSlam();
+    rclcpp::shutdown();
+}
+
+int main(int argc, char **argv)
+{
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+    signal(SIGKILL, signal_handler);
+
+    rclcpp::init(argc, argv);
+
+    node_ = std::make_shared<VSLAM>();
+    rclcpp::spin(node_);
+    rclcpp::shutdown();
+
+    return 0;
+}


### PR DESCRIPTION
This is pretty big code re-factor adding an ability to use lpslam_node with OpenVSLAM directly without "lpslam" module. This change intention to adjust the work more logically with ROS2, as for ROS purposes "lpslam" (containing the support for different vendor-specific sensors and various post-processing units) is excess. For backward compatibility, the old node behavior (`lpslam_node` <-> `lpslam` <-> `lp-openvslam)` remains to be untouched.

The main features of change are:
* Ability to use OpenVSLAM directly by (`lpslam_node` <-> `lp-openvslam`) scheme
* Switch stereo image subscription model to TimeSynchronizers (for direct mode)
* Do not use any VSLAM output unless it won't be started (which fixes rare segfault crashes appears due to non-started slam module is being requested for any outputs, such as OccGrid map or PCL).

Since there are a lot of common for both: lpslam and direct openvslam interaction modes, it was decided to move all common stuff to basic `LpBaseNode` class and separate the usage of two interaction-related models into derived classes: `LpSlamNode` and `OpenVSLAMNode`. `LpSlamNode` represents previous usage model while `OpenVSLAMNode` operates with OpenVSLAM directly. The switch between `LpSlamNode` and `OpenVSLAMNode` classes is done using a `USE_OPENVSLAM_DIRECTLY` macro. The overall re-factoring scheme is presented at the diagram below:
![lpslam_node_refactoring](https://user-images.githubusercontent.com/60094858/145217520-8d86a70d-efe2-4fb6-8983-b7de069a9064.png)

All related changes and dependencies were also included into `CMakeLists.txt`. There direct usage of OpenVSLAM is being supported for both conan and manual OpenVSLAM build methods, described in [LP docs](https://lp-research.atlassian.net/wiki/spaces/LKB/pages/1750761481/LPSLAM+for+ROS2+Documentation#Build-instructions). The table below represents options introduced for linking `lpslam_node` with `openvslam` after this change:
```
|           linking model              |      conan build        |   manual build  |
____________________________________________________________________________________
| lpslam_node <-> OpenVSLAM directly   |  supported (new)        | supported (new) |
| lspam_node <-> LpSlam <-> OpenVSLAM  |  supported (unchanged)  | not supported   |
```

All 3 supported options were built from the scratch and tested with Nav2 stack with `lpslam_node` operating as SLAM.

_Alternative option considered:_
There was another option to make two separate nodes: remain previous version of `LpSlamNode.cpp` node to be untouched and develop new `OpenVSLAMNode.cpp` node from the scratch. This node responsible for direct operating with openvslam will absorb all common code from old `LpSlamNode.cpp`. However, since this common for both `LpSlam` and `OpenVSLAM` parts of code is about ~50% of initial `LpSlamNode.cpp` volume, an alternative option was decided to be dropped in favor of presented in this PR solution. It was considered as unreasonable if a code base of thousand lines begins to crawl off in the future followed by further boilerplate code synchronizing work.

Thus, I am open for any discussion whether this patch is requiring some re-processing if you are not agree with the concept.