### PR TITLE
Switch to ros2 components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,18 +60,16 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-set(node_plugins "")
-
 ## Build
-SET(LPSLAM_NODE_SRC src/LpBaseNode.cpp)
+SET(LPSLAM_COMPONENTS_SRC src/LpBaseNode.cpp)
 if(USE_OPENVSLAM_DIRECTLY)
-  LIST(APPEND LPSLAM_NODE_SRC src/OpenVSLAMNode.cpp)
+  LIST(APPEND LPSLAM_COMPONENTS_SRC src/OpenVSLAMNode.cpp)
 else()
-  LIST(APPEND LPSLAM_NODE_SRC src/LpSlamNode.cpp)
+  LIST(APPEND LPSLAM_COMPONENTS_SRC src/LpSlamNode.cpp)
 endif()
 
-add_library(lpslam_component SHARED
-  ${LPSLAM_NODE_SRC}
+add_library(lpslam_components SHARED
+  ${LPSLAM_COMPONENTS_SRC}
 )
 
 SET(LPSLAM_NODE_LIBS
@@ -80,7 +78,7 @@ SET(LPSLAM_NODE_LIBS
 
 if(USE_OPENVSLAM_DIRECTLY)
   LIST(APPEND LPSLAM_NODE_LIBS openvslam)
-  target_include_directories(lpslam_component
+  target_include_directories(lpslam_components
     PRIVATE
     lpslam/src/Interface)
 
@@ -96,7 +94,7 @@ else()
   LIST(APPEND LPSLAM_NODE_LIBS lpslam)
 endif()
 
-target_link_libraries(lpslam_component
+target_link_libraries(lpslam_components
   ${LPSLAM_NODE_LIBS}
 )
 
@@ -114,37 +112,36 @@ SET(LPSLAM_NODE_DEPS
 
 if(USE_OPENVSLAM_DIRECTLY)
   LIST(APPEND LPSLAM_NODE_DEPS message_filters builtin_interfaces cv_bridge)
-  target_compile_definitions(lpslam_component PRIVATE -DUSE_OPENVSLAM_DIRECTLY)
+  target_compile_definitions(lpslam_components PRIVATE -DUSE_OPENVSLAM_DIRECTLY)
 else()
   LIST(APPEND LPSLAM_NODE_DEPS lpslam_interfaces)
 endif()
 
 if(USE_PANGOLIN_VIEWER)
-  target_compile_definitions(lpslam_component PRIVATE -DUSE_PANGOLIN_VIEWER)
+  target_compile_definitions(lpslam_components PRIVATE -DUSE_PANGOLIN_VIEWER)
 endif()
 
-ament_target_dependencies(lpslam_component
+ament_target_dependencies(lpslam_components
   ${LPSLAM_NODE_DEPS})
 
 if(USE_OPENVSLAM_DIRECTLY)
-  rclcpp_components_register_nodes(lpslam_component "lpslam_components::OpenVSLAMNode")
-  set(node_plugins "${node_plugins}lpslam_components::OpenVSLAMNode;$<TARGET_FILE:lpslam_component>\n")
+  rclcpp_components_register_nodes(lpslam_components "lpslam_components::OpenVSLAMNode")
 else()
-  rclcpp_components_register_nodes(lpslam_component "lpslam_components::LpSlamNode")
-  set(node_plugins "${node_plugins}lpslam_components::LpSlamNode;$<TARGET_FILE:lpslam_component>\n")
+  rclcpp_components_register_nodes(lpslam_components "lpslam_components::LpSlamNode")
 endif()
 
 
 add_executable(lpslam_node
   src/main.cpp)
-target_include_directories(lpslam_node
-  PRIVATE
-  lpslam/src/Interface)
+
 
 target_link_libraries(lpslam_node
   ${LPSLAM_NODE_LIBS}
-  lpslam_component)
+  lpslam_components)
 if(USE_OPENVSLAM_DIRECTLY)
+  target_include_directories(lpslam_node
+    PRIVATE
+    lpslam/src/Interface)
   target_compile_definitions(lpslam_node PRIVATE -DUSE_OPENVSLAM_DIRECTLY)
 endif()
 
@@ -154,9 +151,8 @@ endif()
 
 ament_target_dependencies(lpslam_node
   ${LPSLAM_NODE_DEPS})
-  
-install( TARGETS
-  lpslam_component
+install(TARGETS
+  lpslam_components
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ if (USE_OPENVSLAM_DIRECTLY)
 else()
   find_package(lpslam_interfaces REQUIRED)
 endif()
+find_package(rclcpp_components REQUIRED)
 
 SET(LPSLAM_BUILD_ROS2 ON CACHE BOOL "build with ROS2 support")
 SET(LPSLAM_BUILD_LPSLAM ON CACHE BOOL "Build LPSLAM module")
@@ -59,46 +60,47 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-## Build
-SET(LPSPAM_NODE_SRC src/LpBaseNode.cpp)
-if(USE_OPENVSLAM_DIRECTLY)
-  LIST(APPEND LPSPAM_NODE_SRC src/OpenVSLAMNode.cpp)
-else()
-  LIST(APPEND LPSPAM_NODE_SRC src/LpSlamNode.cpp)
-endif()
-LIST(APPEND LPSPAM_NODE_SRC src/main.cpp)
+set(node_plugins "")
 
-add_executable(lpslam_node
-  ${LPSPAM_NODE_SRC}
+## Build
+SET(LPSLAM_NODE_SRC src/LpBaseNode.cpp)
+if(USE_OPENVSLAM_DIRECTLY)
+  LIST(APPEND LPSLAM_NODE_SRC src/OpenVSLAMNode.cpp)
+else()
+  LIST(APPEND LPSLAM_NODE_SRC src/LpSlamNode.cpp)
+endif()
+
+add_library(lpslam_component SHARED
+  ${LPSLAM_NODE_SRC}
 )
 
-SET(LPSPAM_NODE_LIBS
+SET(LPSLAM_NODE_LIBS
   ${OPENZEN_TARGET_NAME}
 )
 
 if(USE_OPENVSLAM_DIRECTLY)
-  LIST(APPEND LPSPAM_NODE_LIBS openvslam)
-  target_include_directories(lpslam_node
+  LIST(APPEND LPSLAM_NODE_LIBS openvslam)
+  target_include_directories(lpslam_component
     PRIVATE
     lpslam/src/Interface)
 
   if(USE_PANGOLIN_VIEWER)
-    LIST(APPEND LPSPAM_NODE_LIBS pangolin_viewer)
+    LIST(APPEND LPSLAM_NODE_LIBS pangolin_viewer)
     if (NOT LPSLAM_BUILD_LPSLAM)
       # If build lpslam with conan, it will add pangolin dependency.
       # Otherwise, adding it manually
-      LIST(APPEND LPSPAM_NODE_LIBS pangolin)
+      LIST(APPEND LPSLAM_NODE_LIBS pangolin)
     endif()
   endif()
 else()
-  LIST(APPEND LPSPAM_NODE_LIBS lpslam)
+  LIST(APPEND LPSLAM_NODE_LIBS lpslam)
 endif()
 
-target_link_libraries(lpslam_node
-  ${LPSPAM_NODE_LIBS}
+target_link_libraries(lpslam_component
+  ${LPSLAM_NODE_LIBS}
 )
 
-SET(LPSPAM_NODE_DEPS
+SET(LPSLAM_NODE_DEPS
   rclcpp
   std_msgs
   sensor_msgs
@@ -107,13 +109,43 @@ SET(LPSPAM_NODE_DEPS
   tf2_ros
   tf2_geometry_msgs
   yaml_cpp_vendor
+  rclcpp_components
 )
 
 if(USE_OPENVSLAM_DIRECTLY)
-  LIST(APPEND LPSPAM_NODE_DEPS message_filters builtin_interfaces cv_bridge)
-  target_compile_definitions(lpslam_node PRIVATE -DUSE_OPENVSLAM_DIRECTLY)
+  LIST(APPEND LPSLAM_NODE_DEPS message_filters builtin_interfaces cv_bridge)
+  target_compile_definitions(lpslam_component PRIVATE -DUSE_OPENVSLAM_DIRECTLY)
 else()
-  LIST(APPEND LPSPAM_NODE_DEPS lpslam_interfaces)
+  LIST(APPEND LPSLAM_NODE_DEPS lpslam_interfaces)
+endif()
+
+if(USE_PANGOLIN_VIEWER)
+  target_compile_definitions(lpslam_component PRIVATE -DUSE_PANGOLIN_VIEWER)
+endif()
+
+ament_target_dependencies(lpslam_component
+  ${LPSLAM_NODE_DEPS})
+
+if(USE_OPENVSLAM_DIRECTLY)
+  rclcpp_components_register_nodes(lpslam_component "lpslam_components::OpenVSLAMNode")
+  set(node_plugins "${node_plugins}lpslam_components::OpenVSLAMNode;$<TARGET_FILE:lpslam_component>\n")
+else()
+  rclcpp_components_register_nodes(lpslam_component "lpslam_components::LpSlamNode")
+  set(node_plugins "${node_plugins}lpslam_components::LpSlamNode;$<TARGET_FILE:lpslam_component>\n")
+endif()
+
+
+add_executable(lpslam_node
+  src/main.cpp)
+target_include_directories(lpslam_node
+  PRIVATE
+  lpslam/src/Interface)
+
+target_link_libraries(lpslam_node
+  ${LPSLAM_NODE_LIBS}
+  lpslam_component)
+if(USE_OPENVSLAM_DIRECTLY)
+  target_compile_definitions(lpslam_node PRIVATE -DUSE_OPENVSLAM_DIRECTLY)
 endif()
 
 if(USE_PANGOLIN_VIEWER)
@@ -121,10 +153,18 @@ if(USE_PANGOLIN_VIEWER)
 endif()
 
 ament_target_dependencies(lpslam_node
-  ${LPSPAM_NODE_DEPS})
-
-install(TARGETS lpslam_node
+  ${LPSLAM_NODE_DEPS})
+  
+install( TARGETS
+  lpslam_component
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)  
+install(TARGETS
+  lpslam_node
   DESTINATION lib/${PROJECT_NAME})
+
 if (LPSLAM_BUILD_LPSLAM)
   install(TARGETS lpslam
     DESTINATION lib/${PROJECT_NAME})

--- a/src/LpBaseNode.cpp
+++ b/src/LpBaseNode.cpp
@@ -21,7 +21,7 @@ https://www.stereolabs.com/docs/ros2/video/
 
 namespace lpslam_components
 {
-    LpBaseNode::LpBaseNode(const rclcpp::NodeOptions & options) : Node("lpslam_node", options)
+LpBaseNode::LpBaseNode(const rclcpp::NodeOptions & options) : Node("lpslam_node", options)
 {
     if (!setParameters()) {
         return;

--- a/src/LpBaseNode.cpp
+++ b/src/LpBaseNode.cpp
@@ -19,7 +19,9 @@ nice explainer:
 https://www.stereolabs.com/docs/ros2/video/
 */
 
-LpBaseNode::LpBaseNode() : Node("lpslam_node")
+namespace lpslam_components
+{
+    LpBaseNode::LpBaseNode(const rclcpp::NodeOptions & options) : Node("lpslam_node", options)
 {
     if (!setParameters()) {
         return;
@@ -495,3 +497,7 @@ LpSlamROSTimestamp LpBaseNode::rosTimeToLpSlam( rclcpp::Time const& ts ) const
 {
     return LpSlamROSTimestamp{0, ts.nanoseconds()};
 }
+
+    
+} // namespace lpslam_components
+

--- a/src/LpBaseNode.hpp
+++ b/src/LpBaseNode.hpp
@@ -30,7 +30,7 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/map_meta_data.hpp>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <cstring>
 #include <memory>
@@ -58,10 +58,12 @@ nice explainer:
 https://www.stereolabs.com/docs/ros2/video/
 */
 
-class LpBaseNode : public rclcpp::Node
+namespace lpslam_components
+{
+    class LpBaseNode : public rclcpp::Node
 {
 public:
-    LpBaseNode();
+    explicit LpBaseNode(const rclcpp::NodeOptions & options);
 
 private:
     bool setParameters();
@@ -184,3 +186,6 @@ protected:
 };
 
 #endif  // LP_BASE_NODE_HPP_
+   
+} // namespace lpslam_components
+

--- a/src/LpBaseNode.hpp
+++ b/src/LpBaseNode.hpp
@@ -60,7 +60,7 @@ https://www.stereolabs.com/docs/ros2/video/
 
 namespace lpslam_components
 {
-    class LpBaseNode : public rclcpp::Node
+class LpBaseNode : public rclcpp::Node
 {
 public:
     explicit LpBaseNode(const rclcpp::NodeOptions & options);

--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "LpSlamNode.hpp"
+namespace lpslam_components
+{
 
 void outside_lpslam_OnReconstructionCallback(LpSlamGlobalStateInTime const &state_in_time, void *lpslam_node)
 {
@@ -37,7 +39,7 @@ LpSlamRequestNavTransformation outside_lpslam_RequestNavTransformationCallback(L
         from_frame, to_frame);
 }
 
-LpSlamNode::LpSlamNode() : LpBaseNode()
+   LpSlamNode::LpSlamNode(const rclcpp::NodeOptions & options) : LpBaseNode(options)
 {
     RCLCPP_INFO(get_logger(), "starting LpSlam node");
 
@@ -550,3 +552,9 @@ void LpSlamNode::stopSlam()
 {
     m_slam.stop();
 }
+ 
+} // namespace lpslam_components
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+RCLCPP_COMPONENTS_REGISTER_NODE(lpslam_components::LpSlamNode)

--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -39,7 +39,7 @@ LpSlamRequestNavTransformation outside_lpslam_RequestNavTransformationCallback(L
         from_frame, to_frame);
 }
 
-   LpSlamNode::LpSlamNode(const rclcpp::NodeOptions & options) : LpBaseNode(options)
+LpSlamNode::LpSlamNode(const rclcpp::NodeOptions & options) : LpBaseNode(options)
 {
     RCLCPP_INFO(get_logger(), "starting LpSlam node");
 

--- a/src/LpSlamNode.hpp
+++ b/src/LpSlamNode.hpp
@@ -32,10 +32,12 @@ LpSlamRequestNavTransformation outside_lpslam_RequestNavTransformationCallback(L
     LpSlamNavDataFrame to_frame,
     void * lpslam_node);
 
-class LpSlamNode : public LpBaseNode
+namespace lpslam_components
+{
+    class LpSlamNode : public LpBaseNode
 {
 public:
-    LpSlamNode();
+    LpSlamNode(const rclcpp::NodeOptions & options);
     ~LpSlamNode();
 
 private:
@@ -109,3 +111,6 @@ private:
 };
 
 #endif  // LP_SLAM_NODE_HPP_
+
+    
+} // namespace lpslam_components

--- a/src/LpSlamNode.hpp
+++ b/src/LpSlamNode.hpp
@@ -34,7 +34,7 @@ LpSlamRequestNavTransformation outside_lpslam_RequestNavTransformationCallback(L
 
 namespace lpslam_components
 {
-    class LpSlamNode : public LpBaseNode
+class LpSlamNode : public LpBaseNode
 {
 public:
     LpSlamNode(const rclcpp::NodeOptions & options);
@@ -67,10 +67,8 @@ private:
     // Config makers
     bool make_lpslam_config();
 
-public:
     void stopSlam();
 
-private:
     // publishers
     std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointcloudPublisher;
     std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>> m_occGridPublisher;

--- a/src/OpenVSLAMNode.cpp
+++ b/src/OpenVSLAMNode.cpp
@@ -14,7 +14,9 @@
 
 #include "OpenVSLAMNode.hpp"
 
-OpenVSLAMNode::OpenVSLAMNode() : LpBaseNode()
+namespace lpslam_components
+{
+    OpenVSLAMNode::OpenVSLAMNode(const rclcpp::NodeOptions & options) : LpBaseNode(options)
 {
     RCLCPP_INFO(get_logger(), "starting OpenVSlam node");
 
@@ -627,3 +629,10 @@ void OpenVSLAMNode::stopSlam()
     m_openVSlam->shutdown();
     m_openVSlam.reset(nullptr);
 }
+
+    
+} // namespace lpslam
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+RCLCPP_COMPONENTS_REGISTER_NODE(lpslam_components::OpenVSLAMNode)

--- a/src/OpenVSLAMNode.cpp
+++ b/src/OpenVSLAMNode.cpp
@@ -16,7 +16,7 @@
 
 namespace lpslam_components
 {
-    OpenVSLAMNode::OpenVSLAMNode(const rclcpp::NodeOptions & options) : LpBaseNode(options)
+OpenVSLAMNode::OpenVSLAMNode(const rclcpp::NodeOptions & options) : LpBaseNode(options)
 {
     RCLCPP_INFO(get_logger(), "starting OpenVSlam node");
 

--- a/src/OpenVSLAMNode.hpp
+++ b/src/OpenVSLAMNode.hpp
@@ -51,7 +51,7 @@ struct FeaturePosition {
 
 namespace lpslam_components
 {
-   class OpenVSLAMNode : public LpBaseNode
+class OpenVSLAMNode : public LpBaseNode
 {
 public:
     OpenVSLAMNode(const rclcpp::NodeOptions & options);
@@ -80,10 +80,8 @@ private:
     void laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
     void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
 
-public:
     void stopSlam();
 
-private:
     // publishers
     std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointcloudPublisher;
     std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>> m_occGridPublisher;

--- a/src/OpenVSLAMNode.hpp
+++ b/src/OpenVSLAMNode.hpp
@@ -49,10 +49,12 @@ struct FeaturePosition {
   float z;
 };
 
-class OpenVSLAMNode : public LpBaseNode
+namespace lpslam_components
+{
+   class OpenVSLAMNode : public LpBaseNode
 {
 public:
-    OpenVSLAMNode();
+    OpenVSLAMNode(const rclcpp::NodeOptions & options);
     ~OpenVSLAMNode();
 
 private:
@@ -123,3 +125,5 @@ private:
 };
 
 #endif  // OPENVSLAM_NODE_HPP_
+ 
+} // namespace lpslam_components

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,9 +34,9 @@ int main(int argc, char **argv)
     rclcpp::NodeOptions options;
 
 
-    auto node_ = std::make_shared<VSLAM>(options);
+    auto node = std::make_shared<VSLAM>(options);
 
-    exec.add_node(node_);
+    exec.add_node(node);
     exec.spin();
 
     rclcpp::shutdown();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,35 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 #ifndef USE_OPENVSLAM_DIRECTLY
 #include "LpSlamNode.hpp"
-#define VSLAM LpSlamNode
+#define VSLAM lpslam_components::LpSlamNode
 #else
 #include "OpenVSLAMNode.hpp"
-#define VSLAM OpenVSLAMNode
+#define VSLAM lpslam_components::OpenVSLAMNode
 #endif  // USE_OPENVSLAM_DIRECTLY
 
-// Signal handler for no-destructor issue:
-// https://answers.ros.org/question/364045/publish-message-on-destructor-works-only-on-rclpy
-// https://stackoverflow.com/questions/58644994/destructor-of-shared-ptr-object-never-called
-// https://github.com/ros2/rclcpp/issues/317
-std::shared_ptr<VSLAM> node_;
-void signal_handler(int /*sig_num*/)
-{
-    node_->stopSlam();
-    rclcpp::shutdown();
-}
 
 int main(int argc, char **argv)
 {
-    signal(SIGINT, signal_handler);
-    signal(SIGTERM, signal_handler);
-    signal(SIGKILL, signal_handler);
+    // Force flush of the stdout buffer.
+    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
     rclcpp::init(argc, argv);
 
-    node_ = std::make_shared<VSLAM>();
-    rclcpp::spin(node_);
+
+    rclcpp::executors::SingleThreadedExecutor exec;
+    rclcpp::NodeOptions options;
+
+
+    auto node_ = std::make_shared<VSLAM>(options);
+
+    exec.add_node(node_);
+    exec.spin();
+
     rclcpp::shutdown();
 
     return 0;


### PR DESCRIPTION
When testing the previous version on a real robot, the image transport was slow specially for higher resolutions and a big part of the image data was lost in communication affecting the `lpslam_node` performance.

This PR transforms the nodes into ros2 components to be able to run the `lpslam_node` and the `stereo camera driver` in one container allowing automatic memory sharing and solving the limitations mentioned above.

Both versions are still being built in a node form as well so can be used as a standalone node depending on the `USE_OPENVSLAM_DIRECTLY` macro as before. 

This will also fix #15 