### PR TITLE
Get camera Z placement from tf instead of hardcoded value

### DIFF
--- a/src/LpBaseNode.cpp
+++ b/src/LpBaseNode.cpp
@@ -456,6 +456,25 @@ bool LpBaseNode::get_camera_color_order(YAML::Node & configNode)
     return false;
 }
 
+// Set camera placement relative to base_link
+bool LpBaseNode::setCameraPlacement()
+{
+    const auto transformTimeout = rclcpp::Duration::from_nanoseconds(0.1 * std::pow(10.0, 9.0));
+    geometry_msgs::msg::TransformStamped transform;
+    rclcpp::Time now = this->get_clock()->now();
+    try {
+        transform = m_tfBuffer->lookupTransform(m_camera_frame_id, m_base_frame_id, now, transformTimeout);
+        m_cameraZ = transform.transform.translation.z;
+        return true;
+
+    } catch (tf2::TransformException & ex) {
+        RCLCPP_INFO(
+        this->get_logger(), "Could not transform %s to %s: %s",
+        m_camera_frame_id.c_str(), m_base_frame_id.c_str(), ex.what());
+        return false;
+    }
+}
+
 LpSlamGlobalStateInTime LpBaseNode::transformToLpSlamGlobalState(geometry_msgs::msg::TransformStamped const& tf) const
 {
     LpSlamGlobalStateInTime ros_state;

--- a/src/LpBaseNode.cpp
+++ b/src/LpBaseNode.cpp
@@ -468,9 +468,11 @@ bool LpBaseNode::setCameraPlacement()
         return true;
 
     } catch (tf2::TransformException & ex) {
-        RCLCPP_INFO(
-        this->get_logger(), "Could not transform %s to %s: %s",
-        m_camera_frame_id.c_str(), m_base_frame_id.c_str(), ex.what());
+        RCLCPP_ERROR(
+            get_logger(), 
+            "Could not transform %s to %s: %s",
+            m_camera_frame_id.c_str(), m_base_frame_id.c_str(),
+            ex.what());
         return false;
     }
 }

--- a/src/LpBaseNode.hpp
+++ b/src/LpBaseNode.hpp
@@ -89,6 +89,8 @@ protected:
     bool make_openvslam_config(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
     bool get_camera_color_order(YAML::Node & configNode);
 
+    bool setCameraPlacement();
+
     // ROS<->LP converters
     LpSlamGlobalStateInTime transformToLpSlamGlobalState(geometry_msgs::msg::TransformStamped const& tf) const;
     rclcpp::Time lpSlamToRosTime( LpSlamROSTimestamp const& ts ) const;
@@ -147,6 +149,8 @@ protected:
     std::string m_openVSlamYaml;
     // whether the camera config was read
     bool m_cameraConfigured;
+    // Camera z placement
+    double m_cameraZ;
 
 private:
     // Indicator that SLAM has been started and one can use its outputs

--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -57,6 +57,11 @@ LpSlamNode::LpSlamNode(const rclcpp::NodeOptions & options) : LpBaseNode(options
     }
 
     setTimers();
+
+    if (!setCameraPlacement()) {
+        RCLCPP_INFO(get_logger(), "No camera transform available, assuming it's mounted at z = 0.0 for now");
+        m_cameraZ = 0.0;
+    }
 }
 
 LpSlamNode::~LpSlamNode()
@@ -248,8 +253,12 @@ void LpSlamNode::publishOccMap()
         occGridMessage.info.origin.position.y);
 
     //  account for higher placement of camera
-    occGridMessage.info.origin.position.z = -1.15;
-
+    if(m_cameraZ == 0.0){
+        // try to set camera placement again
+        setCameraPlacement();
+        RCLCPP_INFO(get_logger(), "Camera z = %f", m_cameraZ);
+    }
+    occGridMessage.info.origin.position.z = m_cameraZ;
     occGridMessage.header.frame_id = m_map_frame_id;
     occGridMessage.header.stamp = this->now();
 

--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -59,7 +59,7 @@ LpSlamNode::LpSlamNode(const rclcpp::NodeOptions & options) : LpBaseNode(options
     setTimers();
 
     if (!setCameraPlacement()) {
-        RCLCPP_INFO(get_logger(), "No camera transform available, assuming it's mounted at z = 0.0 for now");
+        RCLCPP_WARN(get_logger(), "No camera transform available, assuming it's mounted at z = 0.0 for now");
         m_cameraZ = 0.0;
     }
 }

--- a/src/OpenVSLAMNode.cpp
+++ b/src/OpenVSLAMNode.cpp
@@ -36,7 +36,7 @@ OpenVSLAMNode::OpenVSLAMNode(const rclcpp::NodeOptions & options) : LpBaseNode(o
     setTimers();
 
     if (!setCameraPlacement()) {
-        RCLCPP_INFO(get_logger(), "No camera transform available, assuming it's mounted at z = 0.0 for now");
+        RCLCPP_WARN(get_logger(), "No camera transform available, assuming it's mounted at z = 0.0 for now");
         m_cameraZ = 0.0;
     }
 }


### PR DESCRIPTION
This enables getting the camera z placement dynamically from `camera tf` instead of hard-coded value in order to set `occGridMessage.info.origin.position.z` at `base_link` frame level for any camera placement.