### PR TITLE
Add StereoRectifier to the camera parameters file generated from CameraInfo 

### DIFF
--- a/src/LpBaseNode.cpp
+++ b/src/LpBaseNode.cpp
@@ -392,17 +392,17 @@ bool LpBaseNode::make_openvslam_config(const sensor_msgs::msg::CameraInfo::Share
 
     // Stereo rectification parameters
     configNode["StereoRectifier"]["model"] = "perspective";
-    std::vector<double> Dl(std::begin(left_msg->d), std::end(left_msg->d));
-    std::vector<double> Rl(std::begin(left_msg->r), std::end(left_msg->r));
-    std::vector<double> Kl(std::begin(left_msg->k), std::end(left_msg->k));
+    const std::vector<double> Dl(std::begin(left_msg->d), std::end(left_msg->d));
+    const std::vector<double> Rl(std::begin(left_msg->r), std::end(left_msg->r));
+    const std::vector<double> Kl(std::begin(left_msg->k), std::end(left_msg->k));
 
     configNode["StereoRectifier"]["K_left"] = Kl;
     configNode["StereoRectifier"]["D_left"]= Dl;
     configNode["StereoRectifier"]["R_left"] = Rl;
 
-    std::vector<double> Dr(std::begin(right_msg->d), std::end(right_msg->d));
-    std::vector<double> Rr(std::begin(right_msg->r), std::end(right_msg->r));
-    std::vector<double> Kr(std::begin(right_msg->k), std::end(right_msg->k));
+    const std::vector<double> Dr(std::begin(right_msg->d), std::end(right_msg->d));
+    const std::vector<double> Rr(std::begin(right_msg->r), std::end(right_msg->r));
+    const std::vector<double> Kr(std::begin(right_msg->k), std::end(right_msg->k));
 
     configNode["StereoRectifier"]["K_right"] = Kr;
     configNode["StereoRectifier"]["D_right"] = Dr;

--- a/src/LpBaseNode.hpp
+++ b/src/LpBaseNode.hpp
@@ -86,7 +86,7 @@ private:
 
 protected:
     // Config makers
-    bool make_openvslam_config(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
+    bool make_openvslam_config(const sensor_msgs::msg::CameraInfo::SharedPtr right_msg, const sensor_msgs::msg::CameraInfo::SharedPtr left_msg);
     bool get_camera_color_order(YAML::Node & configNode);
 
     // ROS<->LP converters
@@ -120,7 +120,9 @@ protected:
     std::string m_laserscanTopic;
     std::string m_leftImageTopic;
     std::string m_rightImageTopic;
-    std::string m_cameraInfoTopic;
+    bool m_useRosCameraInfo;
+    std::string m_rightCameraInfoTopic;
+    std::string m_leftCameraInfoTopic;
     double m_cameraFps;
     std::string m_pointcloudTopic;
     int m_pointcloudRate;

--- a/src/LpBaseNode.hpp
+++ b/src/LpBaseNode.hpp
@@ -155,6 +155,7 @@ private:
     // (such as Map and PointClounds)
     bool m_slamStarted;
     std::mutex m_slamStartedMutex;
+    std::mutex m_cameraConfiguredMutex;
 
     // Camera color encoding OpenVSLAM parameter
     std::string m_openVSlam_cameraEncoding;
@@ -184,6 +185,18 @@ protected:
     {
         std::lock_guard<std::mutex> lock(m_openVSlam_cameraEncodingMutex);
         return m_openVSlam_cameraEncoding;
+    }
+
+    inline void setCameraConfigured(const bool camera_configured)
+    {
+       std::lock_guard<std::mutex> lock(m_cameraConfiguredMutex);
+       m_cameraConfigured = camera_configured; 
+    }
+
+    inline bool isCameraConfigured()
+    {
+        std::lock_guard<std::mutex> lock(m_cameraConfiguredMutex);
+        return m_cameraConfigured;
     }
 };
 

--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -435,7 +435,7 @@ void LpSlamNode::image_callback_left(const sensor_msgs::msg::Image::SharedPtr ms
         setCameraEncoding(msg->encoding);
     }
     
-    if (m_useRosCameraInfo && !m_cameraConfigured) {
+    if (m_useRosCameraInfo && !isCameraConfigured()) {
         RCLCPP_WARN(get_logger(), "Camera calibration file could not be created from camera info topics. Check your configuration.");
         return;
     }
@@ -505,14 +505,14 @@ void LpSlamNode::laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr
 
 void LpSlamNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr left_msg, const sensor_msgs::msg::CameraInfo::SharedPtr right_msg)
 {
-    if (m_cameraConfigured)
+    if (isCameraConfigured())
     {
         return;
     }
 
     // Make OpenVSLAM config-file
     if (!make_openvslam_config(left_msg, right_msg))
-        {
+    {
         return;
     }
     // Update LP-SLAM config file with prepared OpenVSLAM one
@@ -525,7 +525,7 @@ void LpSlamNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::Shared
     startSlam();
 
     // Once camera was configured, no more actions needed here
-    m_cameraConfigured = true;
+    setCameraConfigured(true);
 }
 
 bool LpSlamNode::make_lpslam_config()

--- a/src/LpSlamNode.cpp
+++ b/src/LpSlamNode.cpp
@@ -50,7 +50,7 @@ LpSlamNode::LpSlamNode(const rclcpp::NodeOptions & options) : LpBaseNode(options
     setSubscribers();
     setPublishers();
 
-    if (m_cameraInfoTopic.empty()) {
+    if (!m_useRosCameraInfo) {
         // Camera calibration files won't be read from topic.
         // Starting SLAM manually.
         startSlam();
@@ -121,11 +121,27 @@ void LpSlamNode::setSubscribers()
             std::bind(&LpSlamNode::image_callback_right, this, std::placeholders::_1));
     }
 
-    if (!m_cameraInfoTopic.empty())
+    if (m_useRosCameraInfo)
     {
-        m_cameraInfoSubscription = this->create_subscription<sensor_msgs::msg::CameraInfo>(
-            m_cameraInfoTopic, video_qos,
-            std::bind(&LpSlamNode::camera_info_callback, this, std::placeholders::_1));
+        rmw_qos_profile_t video_qos = rmw_qos_profile_sensor_data;
+        video_qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+        video_qos.depth = 10;
+        if (m_qosReliability == "best_effort") {
+            video_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+        } else {
+            // reliable
+            video_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+        }
+
+        m_rightCameraInfoSubscription =
+            std::make_shared<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>>(
+                this, m_rightCameraInfoTopic, video_qos);
+        m_leftCameraInfoSubscription = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>>(
+            this, m_leftCameraInfoTopic, video_qos);
+        m_camInfoSynchronizer = std::make_shared<
+            message_filters::TimeSynchronizer<sensor_msgs::msg::CameraInfo, sensor_msgs::msg::CameraInfo>>(
+                *m_leftCameraInfoSubscription, *m_rightCameraInfoSubscription, 10);
+        m_camInfoSynchronizer->registerCallback(&LpSlamNode::camera_info_callback, this);
     }
 }
 
@@ -418,6 +434,11 @@ void LpSlamNode::image_callback_left(const sensor_msgs::msg::Image::SharedPtr ms
     if (camera_encoding.empty()) {
         setCameraEncoding(msg->encoding);
     }
+    
+    if (m_useRosCameraInfo && !m_cameraConfigured) {
+        RCLCPP_WARN(get_logger(), "Camera calibration file could not be created from camera info topics. Check your configuration.");
+        return;
+    }
 
     if (check_and_dispatch(msg, m_rightImageBuffer, m_rightImageTimestamp, m_rightImageMutex, true))
     {
@@ -482,7 +503,7 @@ void LpSlamNode::laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr
     RCLCPP_DEBUG(get_logger(), "Laser data dispatched");
 }
 
-void LpSlamNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg)
+void LpSlamNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr left_msg, const sensor_msgs::msg::CameraInfo::SharedPtr right_msg)
 {
     if (m_cameraConfigured)
     {
@@ -490,8 +511,8 @@ void LpSlamNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::Shared
     }
 
     // Make OpenVSLAM config-file
-    if (!make_openvslam_config(msg))
-    {
+    if (!make_openvslam_config(left_msg, right_msg))
+        {
         return;
     }
     // Update LP-SLAM config file with prepared OpenVSLAM one

--- a/src/LpSlamNode.hpp
+++ b/src/LpSlamNode.hpp
@@ -16,6 +16,8 @@
 #define LP_SLAM_NODE_HPP_
 
 #include "LpBaseNode.hpp"
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/subscriber.h>
 
 #include <lpslam_interfaces/msg/lp_slam_status.hpp>
 #include "LpSlamManager.h"
@@ -62,7 +64,7 @@ private:
     void image_callback_right(const sensor_msgs::msg::Image::SharedPtr msg);
     void image_callback_left(const sensor_msgs::msg::Image::SharedPtr msg);
     void laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
-    void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
+    void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr left_msg, const sensor_msgs::msg::CameraInfo::SharedPtr right_msg);
 
     // Config makers
     bool make_lpslam_config();
@@ -79,7 +81,10 @@ private:
     rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr m_laserScanSubsription;
     rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr m_leftImageSubscription;
     rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr m_rightImageSubscription;
-    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr m_cameraInfoSubscription;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>> m_leftCameraInfoSubscription;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>> m_rightCameraInfoSubscription;
+    std::shared_ptr<message_filters::TimeSynchronizer<sensor_msgs::msg::CameraInfo, sensor_msgs::msg::CameraInfo>>
+            m_camInfoSynchronizer;
 
     // Timers
     std::shared_ptr<rclcpp::TimerBase> m_pointcloud_timer;

--- a/src/OpenVSLAMNode.cpp
+++ b/src/OpenVSLAMNode.cpp
@@ -388,7 +388,7 @@ void OpenVSLAMNode::image_callback_stereo(
         return;
     }
 
-    if (m_useRosCameraInfo && !m_cameraConfigured) {
+    if (m_useRosCameraInfo && !isCameraConfigured()) {
         RCLCPP_WARN(get_logger(), "Camera calibration file could not be created from camera info topics. Check your configuration.");
         return;
     }
@@ -600,7 +600,7 @@ void OpenVSLAMNode::laserscan_callback(const sensor_msgs::msg::LaserScan::Shared
 
 void OpenVSLAMNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr left_msg, const sensor_msgs::msg::CameraInfo::SharedPtr right_msg)
 {
-    if (m_cameraConfigured)
+    if (isCameraConfigured())
     {
         return;
     }
@@ -615,7 +615,7 @@ void OpenVSLAMNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::Sha
     startSlam();
 
     // Once camera was configured, no more actions needed here
-    m_cameraConfigured = true;
+    setCameraConfigured(true);
 }
 
 void OpenVSLAMNode::stopSlam()

--- a/src/OpenVSLAMNode.cpp
+++ b/src/OpenVSLAMNode.cpp
@@ -27,7 +27,7 @@ OpenVSLAMNode::OpenVSLAMNode(const rclcpp::NodeOptions & options) : LpBaseNode(o
     setSubscribers();
     setPublishers();
 
-    if (m_cameraInfoTopic.empty()) {
+    if (!m_useRosCameraInfo) {
         // Camera calibration files won't be read from topic.
         // Starting SLAM manually.
         startSlam();
@@ -119,22 +119,29 @@ void OpenVSLAMNode::setSubscribers()
         m_synchronizer->registerCallback(&OpenVSLAMNode::image_callback_stereo, this);
     }
 
-    if (!m_cameraInfoTopic.empty())
+    if (m_useRosCameraInfo)
     {
         // allow for relaxed QoS for image in order to match
         // the topic settings
-        auto video_qos = rclcpp::QoS(rclcpp::SensorDataQoS());
-        video_qos.keep_last(10);
+        rmw_qos_profile_t video_qos = rmw_qos_profile_sensor_data;
+        video_qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+        video_qos.depth = 10;
         if (m_qosReliability == "best_effort") {
-            video_qos.best_effort();
+            video_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
         } else {
             // reliable
-            video_qos.reliable();
+            video_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
         }
 
-        m_cameraInfoSubscription = this->create_subscription<sensor_msgs::msg::CameraInfo>(
-            m_cameraInfoTopic, video_qos,
-            std::bind(&OpenVSLAMNode::camera_info_callback, this, std::placeholders::_1));
+        m_rightCameraInfoSubscription =
+            std::make_shared<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>>(
+                this, m_rightCameraInfoTopic, video_qos);
+        m_leftCameraInfoSubscription = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>>(
+            this, m_leftCameraInfoTopic, video_qos);
+        m_camInfoSynchronizer = std::make_shared<
+            message_filters::TimeSynchronizer<sensor_msgs::msg::CameraInfo, sensor_msgs::msg::CameraInfo>>(
+                *m_leftCameraInfoSubscription, *m_rightCameraInfoSubscription, 10);
+        m_camInfoSynchronizer->registerCallback(&OpenVSLAMNode::camera_info_callback, this);
     }
 }
 
@@ -381,6 +388,11 @@ void OpenVSLAMNode::image_callback_stereo(
         return;
     }
 
+    if (m_useRosCameraInfo && !m_cameraConfigured) {
+        RCLCPP_WARN(get_logger(), "Camera calibration file could not be created from camera info topics. Check your configuration.");
+        return;
+    }
+
     if (!m_useOdometry) {
         // Don't continue if there is no odometry data
         RCLCPP_WARN(get_logger(), "Odometry data was disabled, skipping frame");
@@ -586,7 +598,7 @@ void OpenVSLAMNode::laserscan_callback(const sensor_msgs::msg::LaserScan::Shared
     RCLCPP_DEBUG(get_logger(), "Laser data dispatched");
 }
 
-void OpenVSLAMNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg)
+void OpenVSLAMNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr left_msg, const sensor_msgs::msg::CameraInfo::SharedPtr right_msg)
 {
     if (m_cameraConfigured)
     {
@@ -594,7 +606,7 @@ void OpenVSLAMNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::Sha
     }
 
     // Make OpenVSLAM config-file
-    if (!make_openvslam_config(msg))
+    if (!make_openvslam_config(left_msg, right_msg))
     {
         return;
     }

--- a/src/OpenVSLAMNode.hpp
+++ b/src/OpenVSLAMNode.hpp
@@ -78,7 +78,7 @@ private:
         const sensor_msgs::msg::Image::SharedPtr left,
         const sensor_msgs::msg::Image::SharedPtr right);
     void laserscan_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
-    void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr msg);
+    void camera_info_callback(const sensor_msgs::msg::CameraInfo::SharedPtr left_msg, const sensor_msgs::msg::CameraInfo::SharedPtr right_msg);
 
     void stopSlam();
 
@@ -93,8 +93,10 @@ private:
     std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> m_rightImageSubscription;
     std::shared_ptr<message_filters::TimeSynchronizer<sensor_msgs::msg::Image, sensor_msgs::msg::Image>>
             m_synchronizer;
-    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr m_cameraInfoSubscription;
-
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>> m_leftCameraInfoSubscription;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>> m_rightCameraInfoSubscription;
+    std::shared_ptr<message_filters::TimeSynchronizer<sensor_msgs::msg::CameraInfo, sensor_msgs::msg::CameraInfo>>
+            m_camInfoSynchronizer;
     // Timers
     std::shared_ptr<rclcpp::TimerBase> m_pointcloud_timer;
     std::shared_ptr<rclcpp::TimerBase> m_occmap_timer;


### PR DESCRIPTION
In order to have a complete camera configuration for `OpenVSLAM`, Stereo rectification parameters for left and right cameras must be read from ROS camera info topics as well as the other parameters when the file is being generated automatically. The changes are mainly the following,
- Subscribe to both right and left camera info topics and use `message_filters::TimeSynchronizer` to use the same callback.
- Read the missing data and write it in the generated yaml file.
